### PR TITLE
[FEAT] addSubview custom

### DIFF
--- a/AMaDda.xcodeproj/project.pbxproj
+++ b/AMaDda.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		91FD28B52884F55C00F49D20 /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28B42884F55C00F49D20 /* Size.swift */; };
 		91FD28B82884F70A00F49D20 /* FontsPlaceHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28B72884F70A00F49D20 /* FontsPlaceHolder.swift */; };
 		D7ADBBA72883D520004BB5FE /* CommonButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADBBA62883D520004BB5FE /* CommonButton.swift */; };
+		E6278AE52884FCF500DC0CB0 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		91FD28B42884F55C00F49D20 /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		91FD28B72884F70A00F49D20 /* FontsPlaceHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontsPlaceHolder.swift; sourceTree = "<group>"; };
 		D7ADBBA62883D520004BB5FE /* CommonButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonButton.swift; sourceTree = "<group>"; };
+		E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				91FD28B12884F4B800F49D20 /* Color+Extension.swift */,
+				E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -255,6 +258,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6278AE52884FCF500DC0CB0 /* UIView+Extension.swift in Sources */,
 				91FD28B22884F4B800F49D20 /* Color+Extension.swift in Sources */,
 				91FD28B82884F70A00F49D20 /* FontsPlaceHolder.swift in Sources */,
 				3E622CEE28803971006A921C /* AppDelegate.swift in Sources */,

--- a/AMaDda/Global/Extension/UIView+Extension.swift
+++ b/AMaDda/Global/Extension/UIView+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  UIView+Extension.swift
+//  AMaDda
+//
+//  Created by sanghyo on 2022/07/18.
+//
+
+import UIKit
+
+extension UIView {
+    func addSubviews(_ views: UIView...) {
+        for view in views {
+            addSubview(view)
+        }
+    }
+}

--- a/AMaDda/Screens/Main/Views/TodayQuestionView.swift
+++ b/AMaDda/Screens/Main/Views/TodayQuestionView.swift
@@ -34,9 +34,7 @@ final class TodayQuestionView: UIView {
 extension TodayQuestionView {
     // MARK: - configure
     func configureAddSubViewsTodayQuestionView() {
-        addSubview(todayTitleLabel)
-        addSubview(todayCardView)
-        addSubview(todayCardQuestionLabel)
+        addSubviews(todayTitleLabel, todayCardView, todayCardQuestionLabel)
     }
     func configureConstraintsTodayQuestionView() {
         todayTitleLabel.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# 이슈 번호
🔒 Close #26 

## 구현 / 변경 사항 이유
```swift
extension UIView {
    func addSubviews(_ views: UIView...) {
        for view in views {
            addSubview(view)
        }
    }
}
```
위와 같이 구현하여 addSubview를 여러번할 필요가 없도록 구현하였습니다.
예시를 위해서 고반의 코드에 적용시켜서 아래와 같이 사용했습니다. 넓은 이해 부탁드립니다 ㅎㅎ
```swift
func configureAddSubViewsTodayQuestionView() {
        addSubviews(todayTitleLabel, todayCardView, todayCardQuestionLabel)
    }
```
## 리뷰 포인트
- 코드를 더 간단히짤 수 있다면 조언 부탁드려요
## 추후 진행할 사항
- [ ] 기존에 addSubview를 개별로 적용했던 부분들에 해당 함수를 적용시키면 좋을 것 같습니다.

## References
https://stackoverflow.com/questions/65066854/three-dots-in-swift-init-method

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

