### PR TITLE
[FEAT] 온보딩1 UI 구현

### DIFF
--- a/AMaDda.xcodeproj/project.pbxproj
+++ b/AMaDda.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3E622CF528803971006A921C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF328803971006A921C /* Main.storyboard */; };
 		3E622CF728803972006A921C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF628803972006A921C /* Assets.xcassets */; };
 		3E622CFA28803972006A921C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF828803972006A921C /* LaunchScreen.storyboard */; };
+		595E3B41288577D60036B677 /* OnboardingOneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595E3B40288577D60036B677 /* OnboardingOneViewController.swift */; };
 		91FD28A82884F32700F49D20 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A72884F32700F49D20 /* MainViewController.swift */; };
 		91FD28AA2884F3E500F49D20 /* TodayQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */; };
 		91FD28AD2884F43A00F49D20 /* TodayQuestionMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28AC2884F43A00F49D20 /* TodayQuestionMockData.swift */; };
@@ -30,6 +31,7 @@
 		3E622CF628803972006A921C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3E622CF928803972006A921C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3E622CFB28803972006A921C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		595E3B40288577D60036B677 /* OnboardingOneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOneViewController.swift; sourceTree = "<group>"; };
 		91FD28A72884F32700F49D20 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionView.swift; sourceTree = "<group>"; };
 		91FD28AC2884F43A00F49D20 /* TodayQuestionMockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionMockData.swift; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 		3E622D0128803BBD006A921C /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				595E3B3E288577B30036B677 /* Onboarding */,
 				3E622D0928803C44006A921C /* Main */,
 			);
 			path = Screens;
@@ -133,6 +136,14 @@
 				3E622CF328803971006A921C /* Main.storyboard */,
 			);
 			path = Storyboards;
+			sourceTree = "<group>";
+		};
+		595E3B3E288577B30036B677 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				595E3B40288577D60036B677 /* OnboardingOneViewController.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		91FD28A62884F30E00F49D20 /* Views */ = {
@@ -264,6 +275,7 @@
 				91FD28AF2884F44100F49D20 /* TodayQuestionData.swift in Sources */,
 				91FD28AD2884F43A00F49D20 /* TodayQuestionMockData.swift in Sources */,
 				91FD28B52884F55C00F49D20 /* Size.swift in Sources */,
+				595E3B41288577D60036B677 /* OnboardingOneViewController.swift in Sources */,
 				91FD28A82884F32700F49D20 /* MainViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -13,8 +13,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let _ = (scene as? UIWindowScene) else { return }
-        window = UIWindow(windowScene: scene as! UIWindowScene)
+        guard let windowScene = scene as? UIWindowScene else { return }
+        window = UIWindow(windowScene: windowScene)
         window?.rootViewController = OnboardingOneViewController()
         window?.makeKeyAndVisible()
     }

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -13,10 +13,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let windowScene = scene as? UIWindowScene else { return }
-        window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = OnboardingOneViewController()
-        window?.makeKeyAndVisible()
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+         window = UIWindow(windowScene: windowScene)
+         let mainVC = MainViewController()
+         window?.rootViewController = mainVC
+         window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -13,14 +13,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let windowScene = (scene as? UIWindowScene) else { return }
-         window = UIWindow(windowScene: windowScene)
-         let mainVC = MainViewController()
-         window?.rootViewController = mainVC
-         window?.makeKeyAndVisible()
+        guard let _ = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: scene as! UIWindowScene)
+        window?.rootViewController = OnboardingOneViewController()
+        window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
          window = UIWindow(windowScene: windowScene)
-         let mainVC = MainViewController()
+         let mainVC = MainViewController()	
          window?.rootViewController = mainVC
          window?.makeKeyAndVisible()
     }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -34,28 +34,43 @@ class OnboardingOneViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        render()
+        configureUI()
+        configureAddSubView()
+        configureConstraints()
     }
     
-    func render(){
+    private func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+    
+    private func configureAddSubView() {
+        view.addSubview(FirstOnboardTitle)
+        view.addSubview(FirstOnboardingview)
+        view.addSubview(nextButton)
+    }
+    
+    func configureConstraints(){
         view.backgroundColor = .systemBackground
         
-        view.addSubview(FirstOnboardTitle)
         FirstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
-        FirstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48).isActive = true
-        FirstOnboardTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor).isActive = true
-        FirstOnboardTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor).isActive = true
+        NSLayoutConstraint.activate([
+            FirstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
+            FirstOnboardTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+            FirstOnboardTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor)
+        ])
         
-        view.addSubview(FirstOnboardingview)
         FirstOnboardingview.translatesAutoresizingMaskIntoConstraints = false
-        FirstOnboardingview.topAnchor.constraint(equalTo: FirstOnboardTitle.bottomAnchor, constant: 34).isActive = true
-        FirstOnboardingview.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        FirstOnboardingview.widthAnchor.constraint(equalToConstant: 240).isActive = true
-        FirstOnboardingview.heightAnchor.constraint(equalToConstant: 480).isActive = true
+        NSLayoutConstraint.activate([
+            FirstOnboardingview.topAnchor.constraint(equalTo: FirstOnboardTitle.bottomAnchor, constant: 34),
+            FirstOnboardingview.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            FirstOnboardingview.widthAnchor.constraint(equalToConstant: 240),
+            FirstOnboardingview.heightAnchor.constraint(equalToConstant: 480)
+        ])
         
-        view.addSubview(nextButton)
         nextButton.translatesAutoresizingMaskIntoConstraints = false
-        nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        nextButton.topAnchor.constraint(equalTo: FirstOnboardingview.bottomAnchor, constant: 34).isActive = true
+        NSLayoutConstraint.activate([
+            nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            nextButton.topAnchor.constraint(equalTo: FirstOnboardingview.bottomAnchor, constant: 34)
+        ])
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -18,6 +18,12 @@ class OnboardingOneViewController: UIViewController {
         return label
     }()
     
+    private lazy var FirstOnboardingview: UIImageView = {
+        let FirstOnboardingview = UIImageView()
+        FirstOnboardingview.image = UIImage(named: "onboardingImage.png")
+        return FirstOnboardingview
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         render()
@@ -31,5 +37,12 @@ class OnboardingOneViewController: UIViewController {
         FirstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48).isActive = true
         FirstOnboardTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor).isActive = true
         FirstOnboardTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor).isActive = true
+        
+        view.addSubview(FirstOnboardingview)
+        FirstOnboardingview.translatesAutoresizingMaskIntoConstraints = false
+        FirstOnboardingview.topAnchor.constraint(equalTo: FirstOnboardTitle.bottomAnchor, constant: 34).isActive = true
+        FirstOnboardingview.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        FirstOnboardingview.widthAnchor.constraint(equalToConstant: 240).isActive = true
+        FirstOnboardingview.heightAnchor.constraint(equalToConstant: 480).isActive = true
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class OnboardingOneViewController: UIViewController {
     // MARK: Properties
-    private lazy var FirstOnboardTitle: UILabel = {
+    private let firstOnboardTitle: UILabel = {
         let label = UILabel()
         label.text = "일정시간마다 연락에 대한 알림을 받을 수 있어요"
         label.font = .boldSystemFont(ofSize: 25)
@@ -18,13 +18,13 @@ class OnboardingOneViewController: UIViewController {
         return label
     }()
     
-    private lazy var FirstOnboardingview: UIImageView = {
+    private let firstOnboardingview: UIImageView = {
         let FirstOnboardingview = UIImageView()
         FirstOnboardingview.image = UIImage(named: "onboardingImage.png")
         return FirstOnboardingview
     }()
     
-    private lazy var nextButton: UIButton = {
+    private let nextButton: UIButton = {
         let button = UIButton()
         button.setTitle("다음", for: UIControl.State.normal)
         button.setTitleColor(.systemBlue, for: .normal)
@@ -44,33 +44,33 @@ class OnboardingOneViewController: UIViewController {
     }
     
     private func configureAddSubView() {
-        view.addSubview(FirstOnboardTitle)
-        view.addSubview(FirstOnboardingview)
+        view.addSubview(firstOnboardTitle)
+        view.addSubview(firstOnboardingview)
         view.addSubview(nextButton)
     }
     
     func configureConstraints(){
         view.backgroundColor = .systemBackground
         
-        FirstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
+        firstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            FirstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-            FirstOnboardTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            FirstOnboardTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor)
+            firstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
+            firstOnboardTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+            firstOnboardTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor)
         ])
         
-        FirstOnboardingview.translatesAutoresizingMaskIntoConstraints = false
+        firstOnboardingview.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            FirstOnboardingview.topAnchor.constraint(equalTo: FirstOnboardTitle.bottomAnchor, constant: 34),
-            FirstOnboardingview.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            FirstOnboardingview.widthAnchor.constraint(equalToConstant: 240),
-            FirstOnboardingview.heightAnchor.constraint(equalToConstant: 480)
+            firstOnboardingview.topAnchor.constraint(equalTo: firstOnboardTitle.bottomAnchor, constant: 34),
+            firstOnboardingview.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            firstOnboardingview.widthAnchor.constraint(equalToConstant: 240),
+            firstOnboardingview.heightAnchor.constraint(equalToConstant: 480)
         ])
         
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            nextButton.topAnchor.constraint(equalTo: FirstOnboardingview.bottomAnchor, constant: 34)
+            nextButton.topAnchor.constraint(equalTo: firstOnboardingview.bottomAnchor, constant: 34)
         ])
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -28,9 +28,7 @@ class OnboardingOneViewController: UIViewController {
         let button = UIButton()
         button.setTitle("다음", for: UIControl.State.normal)
         button.setTitleColor(.systemBlue, for: .normal)
-        button.frame = CGRect(x: 15, y: -50, width: 300, height: 500)
         // TODO: Button Function을 필요로 한다.
-        // button.addTarget(self, action: #selector(requestNotificationPermission), for: .touchUpInside)
         return button
     }()
     

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -1,0 +1,35 @@
+//
+//  OnboardingOne.swift
+//  AMaDda
+//
+//  Created by Seik Oh on 2022/07/18.
+//
+
+import UIKit
+
+class OnboardingOneViewController: UIViewController {
+    // MARK: Properties
+    private lazy var FirstOnboardTitle: UILabel = {
+        let label = UILabel()
+        label.text = "일정시간마다 연락에 대한 알림을 받을 수 있어요"
+        label.font = .boldSystemFont(ofSize: 25)
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        return label
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        render()
+    }
+    
+    func render(){
+        view.backgroundColor = .systemBackground
+        
+        view.addSubview(FirstOnboardTitle)
+        FirstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
+        FirstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48).isActive = true
+        FirstOnboardTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor).isActive = true
+        FirstOnboardTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor).isActive = true
+    }
+}

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -11,10 +11,15 @@ class OnboardingOneViewController: UIViewController {
     // MARK: Properties
     private let firstOnboardTitle: UILabel = {
         let label = UILabel()
-        label.text = "일정시간마다 연락에 대한 알림을 받을 수 있어요"
         label.font = .boldSystemFont(ofSize: 25)
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
+        
+        let attributedString = NSMutableAttributedString(string: "일정시간마다 연락에 대한\n알림을 받을 수 있어요")
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 10
+        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value:paragraphStyle, range:NSMakeRange(0, attributedString.length))
+        label.attributedText = attributedString
+        
         return label
     }()
     

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -54,8 +54,8 @@ class OnboardingOneViewController: UIViewController {
         firstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             firstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-            firstOnboardTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            firstOnboardTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor)
+            firstOnboardTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: Size.leadingTrailingPadding),
+            firstOnboardTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding)
         ])
         
         firstOnboardingview.translatesAutoresizingMaskIntoConstraints = false

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -24,10 +24,9 @@ class OnboardingOneViewController: UIViewController {
         return firstOnboardingview
     }()
     
-    private let nextButton: UIButton = {
-        let button = UIButton()
+    private let nextButton: CommonButton = {
+        let button = CommonButton()
         button.setTitle("다음", for: UIControl.State.normal)
-        button.setTitleColor(.systemBlue, for: .normal)
         // TODO: Button Function을 필요로 한다.
         return button
     }()
@@ -70,7 +69,7 @@ class OnboardingOneViewController: UIViewController {
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            nextButton.topAnchor.constraint(equalTo: firstOnboardingview.bottomAnchor, constant: 34)
+            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -42)
         ])
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -19,9 +19,9 @@ class OnboardingOneViewController: UIViewController {
     }()
     
     private let firstOnboardingview: UIImageView = {
-        let FirstOnboardingview = UIImageView()
-        FirstOnboardingview.image = UIImage(named: "onboardingImage.png")
-        return FirstOnboardingview
+        let firstOnboardingview = UIImageView()
+        firstOnboardingview.image = UIImage(named: "onboardingImage.png")
+        return firstOnboardingview
     }()
     
     private let nextButton: UIButton = {

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -24,6 +24,16 @@ class OnboardingOneViewController: UIViewController {
         return FirstOnboardingview
     }()
     
+    private lazy var nextButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("다음", for: UIControl.State.normal)
+        button.setTitleColor(.systemBlue, for: .normal)
+        button.frame = CGRect(x: 15, y: -50, width: 300, height: 500)
+        // TODO: Button Function을 필요로 한다.
+        // button.addTarget(self, action: #selector(requestNotificationPermission), for: .touchUpInside)
+        return button
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         render()
@@ -44,5 +54,10 @@ class OnboardingOneViewController: UIViewController {
         FirstOnboardingview.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         FirstOnboardingview.widthAnchor.constraint(equalToConstant: 240).isActive = true
         FirstOnboardingview.heightAnchor.constraint(equalToConstant: 480).isActive = true
+        
+        view.addSubview(nextButton)
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        nextButton.topAnchor.constraint(equalTo: FirstOnboardingview.bottomAnchor, constant: 34).isActive = true
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -23,10 +23,10 @@ class OnboardingOneViewController: UIViewController {
         return label
     }()
     
-    private let firstOnboardingview: UIImageView = {
-        let firstOnboardingview = UIImageView()
-        firstOnboardingview.image = UIImage(named: "onboardingImage.png")
-        return firstOnboardingview
+    private let firstOnboardingView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "onboardingImage.png")
+        return imageView
     }()
     
     private let nextButton: CommonButton = {
@@ -49,7 +49,7 @@ class OnboardingOneViewController: UIViewController {
     
     private func configureAddSubView() {
         view.addSubview(firstOnboardTitle)
-        view.addSubview(firstOnboardingview)
+        view.addSubview(firstOnboardingView)
         view.addSubview(nextButton)
     }
     
@@ -59,22 +59,22 @@ class OnboardingOneViewController: UIViewController {
         firstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             firstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-            firstOnboardTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: Size.leadingTrailingPadding),
-            firstOnboardTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding)
+            firstOnboardTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
+            firstOnboardTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
         ])
         
-        firstOnboardingview.translatesAutoresizingMaskIntoConstraints = false
+        firstOnboardingView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            firstOnboardingview.topAnchor.constraint(equalTo: firstOnboardTitle.bottomAnchor, constant: 34),
-            firstOnboardingview.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            firstOnboardingview.widthAnchor.constraint(equalToConstant: 240),
-            firstOnboardingview.heightAnchor.constraint(equalToConstant: 480)
+            firstOnboardingView.topAnchor.constraint(equalTo: firstOnboardTitle.bottomAnchor, constant: 34),
+            firstOnboardingView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            firstOnboardingView.widthAnchor.constraint(equalToConstant: 240),
+            firstOnboardingView.heightAnchor.constraint(equalToConstant: 480),
         ])
         
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -42)
+            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -42),
         ])
     }
 }


### PR DESCRIPTION
# 이슈 번호
🔒 Close #6

## 구현 / 변경 사항 이유
- 온보딩1 화면의 UI 구현

light mode          |  dark mode
:-------------------------:|:-------------------------:
<img width="250" src="https://user-images.githubusercontent.com/50728605/179501185-379b5915-07d9-4028-985d-4dd9e823c863.png">  |  <img width="250" src="https://user-images.githubusercontent.com/50728605/179501288-f2e24187-4b53-4bf8-9a06-a9c0c66f4934.png">
## 리뷰 포인트
-  ```private lazy var```를 하는 것이 맞는지 그냥 ```private var``` 만으로도 괜찮은지 궁금합니다!
- title을 UIlabel에서 ```.byWorkdWrapping```을 통해서 아이폰 프레임 크기에 따라 개행을 자동을 하도록 했는데, 온보딩이라는 것이 그래도 되는지 잘 모르겠네요. 그리고 현재는 자동으로 정렬이 ```leading```으로 구현이 되어있는데(figma에도 이렇게 되어있어요), 보다보니 ```center``` 정렬을 해야하지 않을까 싶어서 문의드립니다!

## 추후 진행할 사항
- 버튼은 현재 위치만 잡았고, 추후에 만들어진 컴포넌트와 연결작업이 필요합니다. (해당부분은 다른 분께서 연결작업을 할 때 같이 하는 걸로 알고 있습니다!)

## References
- https://www.youtube.com/watch?v=5ebw7uo1LSE&list=PLG9rdv7aU2N4-nuDqAUtfDlKs4iRJaiu7&index=2
- https://stackoverflow.com/questions/24102191/make-a-uibutton-programmatically-in-swift
- https://developer.apple.com/documentation/uikit/nslinebreakmode/nslinebreakbywordwrapping
- https://stackoverflow.com/questions/4865458/dynamically-changing-font-size-of-uilabel

## Checklist

- [ ] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

