### PR TITLE
[FEAT] 온보딩2 UI 구현

### DIFF
--- a/AMaDda.xcodeproj/project.pbxproj
+++ b/AMaDda.xcodeproj/project.pbxproj
@@ -15,8 +15,9 @@
 		3E622CF528803971006A921C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF328803971006A921C /* Main.storyboard */; };
 		3E622CF728803972006A921C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF628803972006A921C /* Assets.xcassets */; };
 		3E622CFA28803972006A921C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF828803972006A921C /* LaunchScreen.storyboard */; };
-		595E3B41288577D60036B677 /* OnboardingOneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595E3B40288577D60036B677 /* OnboardingOneViewController.swift */; };
 		3E98E8E5288652DF001153E4 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E98E8E4288652DF001153E4 /* NSObject+Extension.swift */; };
+		595E3B41288577D60036B677 /* OnboardingOneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595E3B40288577D60036B677 /* OnboardingOneViewController.swift */; };
+		59F2584228868FA9003BC6ED /* OnboardingTwoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F2584128868FA9003BC6ED /* OnboardingTwoViewController.swift */; };
 		91FD28A82884F32700F49D20 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A72884F32700F49D20 /* MainViewController.swift */; };
 		91FD28AA2884F3E500F49D20 /* TodayQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */; };
 		91FD28AD2884F43A00F49D20 /* TodayQuestionMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28AC2884F43A00F49D20 /* TodayQuestionMockData.swift */; };
@@ -30,8 +31,8 @@
 		D7ADBBA72883D520004BB5FE /* CommonButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADBBA62883D520004BB5FE /* CommonButton.swift */; };
 		E6278AD928843F8E00DC0CB0 /* ProfileModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6278AD828843F8E00DC0CB0 /* ProfileModalViewController.swift */; };
 		E6278ADD2884412D00DC0CB0 /* ProfileModalCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6278ADC2884412D00DC0CB0 /* ProfileModalCell.swift */; };
-		E6DCDBDB288652CF001D4F67 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DCDBDA288652CF001D4F67 /* UIViewController+Extension.swift */; };
 		E6278AE52884FCF500DC0CB0 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */; };
+		E6DCDBDB288652CF001D4F67 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DCDBDA288652CF001D4F67 /* UIViewController+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,8 +46,9 @@
 		3E622CF628803972006A921C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3E622CF928803972006A921C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3E622CFB28803972006A921C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		595E3B40288577D60036B677 /* OnboardingOneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOneViewController.swift; sourceTree = "<group>"; };
 		3E98E8E4288652DF001153E4 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
+		595E3B40288577D60036B677 /* OnboardingOneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOneViewController.swift; sourceTree = "<group>"; };
+		59F2584128868FA9003BC6ED /* OnboardingTwoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTwoViewController.swift; sourceTree = "<group>"; };
 		91FD28A72884F32700F49D20 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionView.swift; sourceTree = "<group>"; };
 		91FD28AC2884F43A00F49D20 /* TodayQuestionMockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionMockData.swift; sourceTree = "<group>"; };
@@ -60,8 +62,8 @@
 		D7ADBBA62883D520004BB5FE /* CommonButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonButton.swift; sourceTree = "<group>"; };
 		E6278AD828843F8E00DC0CB0 /* ProfileModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileModalViewController.swift; sourceTree = "<group>"; };
 		E6278ADC2884412D00DC0CB0 /* ProfileModalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileModalCell.swift; sourceTree = "<group>"; };
-		E6DCDBDA288652CF001D4F67 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		E6DCDBDA288652CF001D4F67 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				595E3B40288577D60036B677 /* OnboardingOneViewController.swift */,
+				59F2584128868FA9003BC6ED /* OnboardingTwoViewController.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 				E6278ADD2884412D00DC0CB0 /* ProfileModalCell.swift in Sources */,
 				D72A1E02288558990058EE12 /* UIImage+Extension.swift in Sources */,
 				E6278AE52884FCF500DC0CB0 /* UIView+Extension.swift in Sources */,
+				59F2584228868FA9003BC6ED /* OnboardingTwoViewController.swift in Sources */,
 				91FD28B22884F4B800F49D20 /* Color+Extension.swift in Sources */,
 				D72A1E0028854C9C0058EE12 /* ImageLiteral.swift in Sources */,
 				91FD28B82884F70A00F49D20 /* FontsPlaceHolder.swift in Sources */,

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
          window = UIWindow(windowScene: windowScene)
-         let mainVC = MainViewController()	
+         let mainVC = OnboardingTwoViewController()	
          window?.rootViewController = mainVC
          window?.makeKeyAndVisible()
     }

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
          window = UIWindow(windowScene: windowScene)
-         let mainVC = OnboardingTwoViewController()	
+         let mainVC = OnboardingTwoViewController()
          window?.rootViewController = mainVC
          window?.makeKeyAndVisible()
     }

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
          window = UIWindow(windowScene: windowScene)
-         let mainVC = MainViewController()
+         let mainVC = OnboardingTwoViewController()
          window?.rootViewController = mainVC
          window?.makeKeyAndVisible()
     }

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
          window = UIWindow(windowScene: windowScene)
-         let mainVC = OnboardingTwoViewController()
+         let mainVC = MainViewController()
          window?.rootViewController = mainVC
          window?.makeKeyAndVisible()
     }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -48,9 +48,9 @@ class OnboardingOneViewController: UIViewController {
     }
     
     private func configureAddSubView() {
-        view.addSubview(firstOnboardTitle)
-        view.addSubview(firstOnboardingView)
-        view.addSubview(nextButton)
+        view.addSubviews(firstOnboardTitle,
+                         (firstOnboardingView),
+                         nextButton)
     }
     
     func configureConstraints(){        

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -22,13 +22,11 @@ class OnboardingOneViewController: UIViewController {
         
         return label
     }()
-    
     private let firstOnboardingImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "onboardingImage.png")
         return imageView
     }()
-    
     private let nextButton: CommonButton = {
         let button = CommonButton()
         button.setTitle("다음", for: .normal)
@@ -36,6 +34,7 @@ class OnboardingOneViewController: UIViewController {
         return button
     }()
     
+    // MARK: Life Cycle functions
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -11,19 +11,19 @@ class OnboardingOneViewController: UIViewController {
     // MARK: Properties
     private let firstOnboardTitleLabel: UILabel = {
         let label = UILabel()
-        label.font = .boldSystemFont(ofSize: 25)
-        label.numberOfLines = 0
-        
         let attributedString = NSMutableAttributedString(string: "일정시간마다 연락에 대한\n알림을 받을 수 있어요")
         let paragraphStyle = NSMutableParagraphStyle()
+        
+        label.font = .boldSystemFont(ofSize: 25)
+        label.numberOfLines = 0
+        label.attributedText = attributedString
         paragraphStyle.lineSpacing = 10
         attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value:paragraphStyle, range:NSMakeRange(0, attributedString.length))
-        label.attributedText = attributedString
         
         return label
     }()
     
-    private let firstOnboardingView: UIImageView = {
+    private let firstOnboardingImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "onboardingImage.png")
         return imageView
@@ -43,13 +43,14 @@ class OnboardingOneViewController: UIViewController {
         configureConstraints()
     }
     
+    // MARK: Configures
     private func configureUI() {
         view.backgroundColor = .systemBackground
     }
     
     private func configureAddSubView() {
         view.addSubviews(firstOnboardTitleLabel,
-                         (firstOnboardingView),
+                         firstOnboardingImageView,
                          nextButton)
     }
     
@@ -61,12 +62,12 @@ class OnboardingOneViewController: UIViewController {
             firstOnboardTitleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
         ])
         
-        firstOnboardingView.translatesAutoresizingMaskIntoConstraints = false
+        firstOnboardingImageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            firstOnboardingView.topAnchor.constraint(equalTo: firstOnboardTitleLabel.bottomAnchor, constant: 34),
-            firstOnboardingView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            firstOnboardingView.widthAnchor.constraint(equalToConstant: 240),
-            firstOnboardingView.heightAnchor.constraint(equalToConstant: 480),
+            firstOnboardingImageView.topAnchor.constraint(equalTo: firstOnboardTitleLabel.bottomAnchor, constant: 34),
+            firstOnboardingImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            firstOnboardingImageView.widthAnchor.constraint(equalToConstant: 240),
+            firstOnboardingImageView.heightAnchor.constraint(equalToConstant: 480),
         ])
         
         nextButton.translatesAutoresizingMaskIntoConstraints = false
@@ -74,5 +75,6 @@ class OnboardingOneViewController: UIViewController {
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -42),
         ])
+        
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -31,7 +31,7 @@ class OnboardingOneViewController: UIViewController {
     
     private let nextButton: CommonButton = {
         let button = CommonButton()
-        button.setTitle("다음", for: UIControl.State.normal)
+        button.setTitle("다음", for: .normal)
         // TODO: Button Function을 필요로 한다.
         return button
     }()

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -53,9 +53,7 @@ class OnboardingOneViewController: UIViewController {
         view.addSubview(nextButton)
     }
     
-    func configureConstraints(){
-        view.backgroundColor = .systemBackground
-        
+    func configureConstraints(){        
         firstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             firstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),

--- a/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingOneViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class OnboardingOneViewController: UIViewController {
     // MARK: Properties
-    private let firstOnboardTitle: UILabel = {
+    private let firstOnboardTitleLabel: UILabel = {
         let label = UILabel()
         label.font = .boldSystemFont(ofSize: 25)
         label.numberOfLines = 0
@@ -48,22 +48,22 @@ class OnboardingOneViewController: UIViewController {
     }
     
     private func configureAddSubView() {
-        view.addSubviews(firstOnboardTitle,
+        view.addSubviews(firstOnboardTitleLabel,
                          (firstOnboardingView),
                          nextButton)
     }
     
     func configureConstraints(){        
-        firstOnboardTitle.translatesAutoresizingMaskIntoConstraints = false
+        firstOnboardTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            firstOnboardTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-            firstOnboardTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
-            firstOnboardTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
+            firstOnboardTitleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
+            firstOnboardTitleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
+            firstOnboardTitleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
         ])
         
         firstOnboardingView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            firstOnboardingView.topAnchor.constraint(equalTo: firstOnboardTitle.bottomAnchor, constant: 34),
+            firstOnboardingView.topAnchor.constraint(equalTo: firstOnboardTitleLabel.bottomAnchor, constant: 34),
             firstOnboardingView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             firstOnboardingView.widthAnchor.constraint(equalToConstant: 240),
             firstOnboardingView.heightAnchor.constraint(equalToConstant: 480),

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -67,10 +67,10 @@ class OnboardingTwoViewController: UIViewController {
     }
     
     private func configureAddSubView() {
-        view.addSubview(onboardingTwoTitle)
-        view.addSubview(showNotification)
-        view.addSubview(onboardingStepper)
-        view.addSubview(startButton)
+        view.addSubviews(onboardingTwoTitle,
+                        showNotification,
+                        onboardingStepper,
+                        startButton)
     }
     
     // MARK: Configures

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -1,0 +1,38 @@
+//
+//  OnboardingTwoViewController.swift
+//  AMaDda
+//
+//  Created by Seik Oh on 2022/07/19.
+//
+
+import UIKit
+
+class OnboardingTwoViewController: UIViewController {
+    // MARK: Properties
+    private lazy var onboardingTwoTitle: UILabel = {
+        let label = UILabel()
+        label.text = "며칠에 한 번 가족에게 연락하고 싶으세요?"
+        label.font = .boldSystemFont(ofSize: 25)
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        return label
+    }()
+
+    // MARK: Life Cycle functions
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        render()
+    }
+
+    // MARK: Configures
+    func render(){
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(onboardingTwoTitle)
+        onboardingTwoTitle.translatesAutoresizingMaskIntoConstraints = false
+        onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48).isActive = true
+        onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor).isActive = true
+        onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor).isActive = true
+
+    }
+}

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -12,7 +12,7 @@ class OnboardingTwoViewController: UIViewController {
     var notificationCount = 3
     
     // MARK: Properties
-    private lazy var onboardingTwoTitle: UILabel = {
+    private let onboardingTwoTitle: UILabel = {
         let label = UILabel()
         label.font = .boldSystemFont(ofSize: 25)
         label.numberOfLines = 0
@@ -75,12 +75,11 @@ class OnboardingTwoViewController: UIViewController {
     
     // MARK: Configures
     func configureConstraints(){
-        
         onboardingTwoTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
         onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-        onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-        onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+        onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
+        onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
         ])
         
         showNotification.translatesAutoresizingMaskIntoConstraints = false
@@ -91,7 +90,7 @@ class OnboardingTwoViewController: UIViewController {
         
         onboardingStepper.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-        onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 145),
+        onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 144),
         onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
         

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -41,6 +41,13 @@ class OnboardingTwoViewController: UIViewController {
         return stepper
     }()
     
+    private let startButton: CommonButton = {
+        let button = CommonButton()
+        button.setTitle("시작하기", for: UIControl.State.normal)
+        // TODO: Button Function을 필요로 한다.
+        return button
+    }()
+    
     // MARK: stepper function
     @objc func stepperValueChanged(_ stepper: UIStepper) {
         notificationCount = Int(stepper.value)
@@ -63,26 +70,35 @@ class OnboardingTwoViewController: UIViewController {
         view.addSubview(onboardingTwoTitle)
         view.addSubview(showNotification)
         view.addSubview(onboardingStepper)
+        view.addSubview(startButton)
     }
     
     // MARK: Configures
     func configureConstraints(){
-        view.backgroundColor = .systemBackground
         
-        view.addSubview(onboardingTwoTitle)
         onboardingTwoTitle.translatesAutoresizingMaskIntoConstraints = false
-        onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48).isActive = true
-        onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor).isActive = true
-        onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor).isActive = true
+        NSLayoutConstraint.activate([
+        onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
+        onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+        onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+        ])
         
-        view.addSubview(showNotification)
         showNotification.translatesAutoresizingMaskIntoConstraints = false
-        showNotification.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        showNotification.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        NSLayoutConstraint.activate([
+        showNotification.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        showNotification.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
         
-        view.addSubview(onboardingStepper)
         onboardingStepper.translatesAutoresizingMaskIntoConstraints = false
-        onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 145).isActive = true
-        onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        NSLayoutConstraint.activate([
+        onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 145),
+        onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        ])
+        
+        startButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            startButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -42),
+        ])
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -43,7 +43,7 @@ class OnboardingTwoViewController: UIViewController {
     
     private let startButton: CommonButton = {
         let button = CommonButton()
-        button.setTitle("시작하기", for: UIControl.State.normal)
+        button.setTitle("시작하기", for: .normal)
         // TODO: Button Function을 필요로 한다.
         return button
     }()

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -14,14 +14,15 @@ class OnboardingTwoViewController: UIViewController {
     // MARK: Properties
     private let onboardingTwoTitleLabel: UILabel = {
         let label = UILabel()
-        label.font = .boldSystemFont(ofSize: 25)
-        label.numberOfLines = 0
-        
         let attributedString = NSMutableAttributedString(string: "며칠에 한 번 가족에게 연락하고\n싶으세요?")
         let paragraphStyle = NSMutableParagraphStyle()
+        
+        label.font = .boldSystemFont(ofSize: 25)
+        label.numberOfLines = 0
+        label.attributedText = attributedString
         paragraphStyle.lineSpacing = 10
         attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value:paragraphStyle, range:NSMakeRange(0, attributedString.length))
-        label.attributedText = attributedString
+
         return label
     }()
     

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -25,14 +25,12 @@ class OnboardingTwoViewController: UIViewController {
 
         return label
     }()
-    
     private lazy var showNotificationLabel: UILabel = {
         let label = UILabel()
         label.text = "\(notificationCount)일"
         label.font = .systemFont(ofSize: 40)
         return label
     }()
-    
     private lazy var onboardingStepper: UIStepper = {
         let stepper = UIStepper()
         stepper.value = 3
@@ -41,7 +39,6 @@ class OnboardingTwoViewController: UIViewController {
         stepper.addTarget(self, action: #selector(stepperValueChanged(_:)), for: .valueChanged)
         return stepper
     }()
-    
     private let startButton: CommonButton = {
         let button = CommonButton()
         button.setTitle("시작하기", for: .normal)

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -90,7 +90,7 @@ class OnboardingTwoViewController: UIViewController {
         
         onboardingStepper.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 144),
+            onboardingStepper.topAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 104),
             onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
         

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -14,10 +14,14 @@ class OnboardingTwoViewController: UIViewController {
     // MARK: Properties
     private lazy var onboardingTwoTitle: UILabel = {
         let label = UILabel()
-        label.text = "며칠에 한 번 가족에게 연락하고 싶으세요?"
         label.font = .boldSystemFont(ofSize: 25)
         label.numberOfLines = 0
-        label.lineBreakMode = .byWordWrapping
+        
+        let attributedString = NSMutableAttributedString(string: "며칠에 한 번 가족에게 연락하고\n싶으세요?")
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 10
+        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value:paragraphStyle, range:NSMakeRange(0, attributedString.length))
+        label.attributedText = attributedString
         return label
     }()
     
@@ -46,11 +50,23 @@ class OnboardingTwoViewController: UIViewController {
     // MARK: Life Cycle functions
     override func viewDidLoad() {
         super.viewDidLoad()
-        render()
+        configureUI()
+        configureAddSubView()
+        configureConstraints()
+    }
+    
+    private func configureUI() {
+        view.backgroundColor = .systemBackground
+    }
+    
+    private func configureAddSubView() {
+        view.addSubview(onboardingTwoTitle)
+        view.addSubview(showNotification)
+        view.addSubview(onboardingStepper)
     }
     
     // MARK: Configures
-    func render(){
+    func configureConstraints(){
         view.backgroundColor = .systemBackground
         
         view.addSubview(onboardingTwoTitle)

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -26,7 +26,7 @@ class OnboardingTwoViewController: UIViewController {
         return label
     }()
     
-    private lazy var showNotification: UILabel = {
+    private lazy var showNotificationLabel: UILabel = {
         let label = UILabel()
         label.text = "\(notificationCount)일"
         label.font = .systemFont(ofSize: 40)
@@ -52,7 +52,7 @@ class OnboardingTwoViewController: UIViewController {
     // MARK: stepper function
     @objc func stepperValueChanged(_ stepper: UIStepper) {
         notificationCount = Int(stepper.value)
-        showNotification.text = "\(notificationCount)일"
+        showNotificationLabel.text = "\(notificationCount)일"
     }
     
     // MARK: Life Cycle functions
@@ -63,18 +63,18 @@ class OnboardingTwoViewController: UIViewController {
         configureConstraints()
     }
     
+    // MARK: Configures
     private func configureUI() {
         view.backgroundColor = .systemBackground
     }
     
     private func configureAddSubView() {
         view.addSubviews(onboardingTwoTitleLabel,
-                        showNotification,
+                        showNotificationLabel,
                         onboardingStepper,
                         startButton)
     }
     
-    // MARK: Configures
     func configureConstraints(){
         onboardingTwoTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -83,15 +83,15 @@ class OnboardingTwoViewController: UIViewController {
             onboardingTwoTitleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
         ])
         
-        showNotification.translatesAutoresizingMaskIntoConstraints = false
+        showNotificationLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            showNotification.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            showNotification.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            showNotificationLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            showNotificationLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
         ])
         
         onboardingStepper.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            onboardingStepper.topAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 104),
+            onboardingStepper.topAnchor.constraint(equalTo: showNotificationLabel.bottomAnchor, constant: 104),
             onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
         
@@ -100,5 +100,6 @@ class OnboardingTwoViewController: UIViewController {
             startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             startButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -42),
         ])
+        
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 class OnboardingTwoViewController: UIViewController {
+    
+    var notificationCount = 3
+    
     // MARK: Properties
     private lazy var onboardingTwoTitle: UILabel = {
         let label = UILabel()
@@ -17,22 +20,53 @@ class OnboardingTwoViewController: UIViewController {
         label.lineBreakMode = .byWordWrapping
         return label
     }()
-
+    
+    private lazy var showNotification: UILabel = {
+        let label = UILabel()
+        label.text = "\(notificationCount)일"
+        label.font = .systemFont(ofSize: 40)
+        return label
+    }()
+    
+    private lazy var onboardingStepper: UIStepper = {
+        let stepper = UIStepper()
+        stepper.value = 3
+        stepper.maximumValue = 7
+        stepper.minimumValue = 1
+        stepper.addTarget(self, action: #selector(stepperValueChanged(_:)), for: .valueChanged)
+        return stepper
+    }()
+    
+    // MARK: stepper function
+    @objc func stepperValueChanged(_ stepper: UIStepper) {
+        notificationCount = Int(stepper.value)
+        showNotification.text = "\(notificationCount)일"
+    }
+    
     // MARK: Life Cycle functions
     override func viewDidLoad() {
         super.viewDidLoad()
         render()
     }
-
+    
     // MARK: Configures
     func render(){
         view.backgroundColor = .systemBackground
-
+        
         view.addSubview(onboardingTwoTitle)
         onboardingTwoTitle.translatesAutoresizingMaskIntoConstraints = false
         onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48).isActive = true
         onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor).isActive = true
         onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor).isActive = true
-
+        
+        view.addSubview(showNotification)
+        showNotification.translatesAutoresizingMaskIntoConstraints = false
+        showNotification.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        showNotification.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        
+        view.addSubview(onboardingStepper)
+        onboardingStepper.translatesAutoresizingMaskIntoConstraints = false
+        onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 145).isActive = true
+        onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
     }
 }

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -77,21 +77,21 @@ class OnboardingTwoViewController: UIViewController {
     func configureConstraints(){
         onboardingTwoTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-        onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-        onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
-        onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
+            onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
+            onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
+            onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
         ])
         
         showNotification.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-        showNotification.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        showNotification.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            showNotification.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            showNotification.centerYAnchor.constraint(equalTo: view.centerYAnchor),
         ])
         
         onboardingStepper.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-        onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 144),
-        onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            onboardingStepper.bottomAnchor.constraint(equalTo: showNotification.bottomAnchor, constant: 144),
+            onboardingStepper.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
         
         startButton.translatesAutoresizingMaskIntoConstraints = false

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -12,7 +12,7 @@ class OnboardingTwoViewController: UIViewController {
     var notificationCount = 3
     
     // MARK: Properties
-    private let onboardingTwoTitle: UILabel = {
+    private let onboardingTwoTitleLabel: UILabel = {
         let label = UILabel()
         label.font = .boldSystemFont(ofSize: 25)
         label.numberOfLines = 0
@@ -67,7 +67,7 @@ class OnboardingTwoViewController: UIViewController {
     }
     
     private func configureAddSubView() {
-        view.addSubviews(onboardingTwoTitle,
+        view.addSubviews(onboardingTwoTitleLabel,
                         showNotification,
                         onboardingStepper,
                         startButton)
@@ -75,11 +75,11 @@ class OnboardingTwoViewController: UIViewController {
     
     // MARK: Configures
     func configureConstraints(){
-        onboardingTwoTitle.translatesAutoresizingMaskIntoConstraints = false
+        onboardingTwoTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            onboardingTwoTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
-            onboardingTwoTitle.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
-            onboardingTwoTitle.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
+            onboardingTwoTitleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 48),
+            onboardingTwoTitleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
+            onboardingTwoTitleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
         ])
         
         showNotification.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# 이슈 번호
🔒 Close #37

## 구현 / 변경 사항 이유
- 온보딩2 UI 화면 구현

light mode          |  dark mode
:-------------------------:|:-------------------------:
<img width="250" src="https://user-images.githubusercontent.com/50728605/179700724-1d3d8e1a-d898-48d1-bfe8-d017c7a278ab.gif"> | <img width="250" src="https://user-images.githubusercontent.com/50728605/179701530-f8a0b0dd-efe4-4bab-b994-c2d99de53b42.gif">

## 리뷰 포인트
- 온보딩2 타이틀 구현
- 온보딩2 스탭퍼 UI 구현
- 온보딩2 스탭퍼 기능 구현

## 추후 진행할 사항
- 현재 다크모드를 적용했을 때, 공통 버튼이 보이지 않는 상황이 발생합니다. 이는 Global-UIComponent-CommonButtond의 backgroundColor = .black으로 되어있어서인 것 같은데, 이에 대해서 바꿀 방법에 대해서 생각해보면 좋을 것 같습니다!

## References
- https://stackoverflow.com/questions/39158604/how-to-increase-line-spacing-in-uilabel-in-swift
- https://stackoverflow.com/questions/9627856/is-there-a-way-to-programmatically-change-the-value-of-a-uistepper-based-on-a-ca

## Checklist
- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

