### PR TITLE
[FEAT] main view setting, add button

### DIFF
--- a/AMaDda/Global/Extension/UIImage+Extension.swift
+++ b/AMaDda/Global/Extension/UIImage+Extension.swift
@@ -24,6 +24,13 @@ extension UIImage {
         return image
     }
     
+    static func load(systemName: String, configuration: UIImage.SymbolConfiguration) -> UIImage {
+             guard let image = UIImage(systemName: systemName, withConfiguration: configuration) else {
+                 return UIImage()
+             }
+        return image
+    }
+    
     func resize(to size: CGSize) -> UIImage {
         let image = UIGraphicsImageRenderer(size: size).image { _ in
             draw(in: CGRect(origin: .zero, size: size))

--- a/AMaDda/Global/Literal/ImageLiteral.swift
+++ b/AMaDda/Global/Literal/ImageLiteral.swift
@@ -11,6 +11,7 @@ enum ImageLiterals {
     
     // MARK: - icon
     static var icPlus: UIImage { .load(systemName: "plus") }
+    static var icSetting: UIImage { .load(systemName: "ellipsis.circle") }
     
     // MARK: - button
     static var btnProfile: UIImage { .load(systemName: "person.circle.fill") }

--- a/AMaDda/Global/Literal/ImageLiteral.swift
+++ b/AMaDda/Global/Literal/ImageLiteral.swift
@@ -12,6 +12,8 @@ enum ImageLiterals {
     // MARK: - icon
     static var icPlus: UIImage { .load(systemName: "plus") }
     static var icSetting: UIImage { .load(systemName: "ellipsis.circle") }
+    static var icBell: UIImage { .load(systemName: "bell") }
+    static var icPencil: UIImage { .load(systemName: "pencil") }
     
     // MARK: - button
     static var btnProfile: UIImage { .load(systemName: "person.circle.fill") }

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -25,6 +25,32 @@ final class MainViewController: UIViewController {
         tableView.separatorStyle = .none
         return tableView
     }()
+    private lazy var addMemberButton: UIButton = {
+        let button = UIButton()
+        button.setImage(ImageLiterals.icPlus, for: .normal)
+        button.addTarget(self, action: #selector(tapAddButton(_:)), for: .touchUpInside)
+        return button
+    }()
+    private lazy var settingButton: UIButton = {
+        let button = UIButton()
+        button.setImage(ImageLiterals.icSetting, for: .normal)
+        let notiSetting = UIAction(title: "알림 설정") { _ in
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            if UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }
+        let cycleSetting = UIAction(title: "알림 주기 설정") { [weak self] _ in
+            // TODO: 세팅에서 주기 설정 페이지 이동, 온보딩에서 주기 설정 페이지 각각에 따라 다른 처리 해줘야한다
+            let notiSettingViewController = OnboardingTwoViewController()
+            let notificationCycle = UserDefaults.standard.userNotificationCycle
+            notiSettingViewController.cycleViewMode = .setting(cycle: Double(notificationCycle ?? 3))
+            self?.navigationController?.pushViewController(notiSettingViewController, animated: true)
+        }
+        button.menu = UIMenu(title: "설정", image: nil, identifier: nil, options: .displayInline , children: [notiSetting, cycleSetting])
+        button.showsMenuAsPrimaryAction = true
+        return button
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,6 +58,13 @@ final class MainViewController: UIViewController {
         configureAddSubViews()
         configureConstraints()
         setUpDelegate()
+    }
+    
+    // MARK: - Selector
+    @objc func tapAddButton(_ sender: Any) {
+        guard let sender = sender as? UIButton else { return }
+        let addingViewController = AddingViewController()
+        navigationController?.pushViewController(addingViewController, animated: true)
     }
     
     // MARK: - functions
@@ -50,7 +83,9 @@ extension MainViewController {
     private func configureAddSubViews() {
         view.addSubviews(todayQuestionView,
                          familyTableLabel,
-                         familyTableView)
+                         familyTableView,
+                        addMemberButton,
+                        settingButton)
         todayQuestionView.configureAddSubViewsTodayQuestionView()
     }
     private func configureConstraints() {
@@ -77,6 +112,22 @@ extension MainViewController {
             familyTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Size.leadingTrailingPadding),
             familyTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
             familyTableView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+        ])
+        
+        addMemberButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            addMemberButton.centerYAnchor.constraint(equalTo: familyTableLabel.centerYAnchor),
+            addMemberButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
+            addMemberButton.heightAnchor.constraint(equalToConstant: 24),
+            addMemberButton.widthAnchor.constraint(equalToConstant: 24),
+        ])
+        
+        settingButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            settingButton.centerYAnchor.constraint(equalTo: todayQuestionView.todayTitleLabel.centerYAnchor),
+            settingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
+            settingButton.heightAnchor.constraint(equalToConstant: 24),
+            settingButton.widthAnchor.constraint(equalToConstant: 24),
         ])
     }
 }

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -48,7 +48,6 @@ final class MainViewController: UIViewController {
     
     // MARK: - Selector
     @objc private func tapAddButton(_ sender: Any) {
-        guard let sender = sender as? UIButton else { return }
         let addingViewController = AddingViewController()
         navigationController?.pushViewController(addingViewController, animated: true)
     }
@@ -69,7 +68,7 @@ final class MainViewController: UIViewController {
         let cycleSetting = UIAction(title: "알림 주기 설정", image: ImageLiterals.icPencil) { [weak self] _ in
             let notiSettingViewController = OnboardingTwoViewController()
             let notificationCycle = UserDefaults.standard.userNotificationCycle
-            notiSettingViewController.cycleViewMode = .setting(cycle: Double(notificationCycle ?? 3))
+            notiSettingViewController.cycleViewMode = .setting(cycle: notificationCycle ?? 3)
             self?.navigationController?.pushViewController(notiSettingViewController, animated: true)
         }
         settingButton.menu = UIMenu(options: .displayInline , children: [notiSetting, cycleSetting])

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -31,7 +31,7 @@ final class MainViewController: UIViewController {
         button.addTarget(self, action: #selector(tapAddButton(_:)), for: .touchUpInside)
         return button
     }()
-    private lazy var settingButton: UIButton = {
+    private let settingButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.icSetting, for: .normal)
         button.showsMenuAsPrimaryAction = true

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -60,19 +60,19 @@ final class MainViewController: UIViewController {
     }
     
     private func setButtonMenu() {
-        let notiSetting = UIAction(title: "알림 설정") { _ in
+        let notiSetting = UIAction(title: "알림 설정", image: ImageLiterals.icBell) { _ in
             guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
             if UIApplication.shared.canOpenURL(url) {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
         }
-        let cycleSetting = UIAction(title: "알림 주기 설정") { [weak self] _ in
+        let cycleSetting = UIAction(title: "알림 주기 설정", image: ImageLiterals.icPencil) { [weak self] _ in
             let notiSettingViewController = OnboardingTwoViewController()
             let notificationCycle = UserDefaults.standard.userNotificationCycle
             notiSettingViewController.cycleViewMode = .setting(cycle: Double(notificationCycle ?? 3))
             self?.navigationController?.pushViewController(notiSettingViewController, animated: true)
         }
-        settingButton.menu = UIMenu(title: "설정", image: nil, identifier: nil, options: .displayInline , children: [notiSetting, cycleSetting])
+        settingButton.menu = UIMenu(options: .displayInline , children: [notiSetting, cycleSetting])
     }
 }
 

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -47,7 +47,7 @@ final class MainViewController: UIViewController {
     }
     
     // MARK: - Selector
-    @objc func tapAddButton(_ sender: Any) {
+    @objc private func tapAddButton(_ sender: Any) {
         guard let sender = sender as? UIButton else { return }
         let addingViewController = AddingViewController()
         navigationController?.pushViewController(addingViewController, animated: true)

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -10,9 +10,9 @@ import UIKit
 
 final class MainViewController: UIViewController {
     private var familyMembers = FamilyMemberMockData.familyMemberData
-    
     private let todayQuestionView = TodayQuestionView()
     
+    private let touchAreaSize: CGFloat = 44
     private let familyTableLabel: UILabel = {
         let label = UILabel()
         label.text = "우리 가족"
@@ -27,13 +27,17 @@ final class MainViewController: UIViewController {
     }()
     private lazy var addMemberButton: UIButton = {
         let button = UIButton()
-        button.setImage(ImageLiterals.icPlus, for: .normal)
+        let configuration = UIImage.SymbolConfiguration(pointSize: 24)
+        let image = UIImage.load(systemName: "plus", configuration: configuration)
+        button.setImage(image, for: .normal)
         button.addTarget(self, action: #selector(tapAddButton), for: .touchUpInside)
         return button
     }()
     private let settingButton: UIButton = {
         let button = UIButton()
-        button.setImage(ImageLiterals.icSetting, for: .normal)
+        let configuaration = UIImage.SymbolConfiguration(pointSize: 24)
+        let image = UIImage.load(systemName: "ellipsis.circle", configuration: configuaration)
+        button.setImage(image, for: .normal)
         button.showsMenuAsPrimaryAction = true
         return button
     }()
@@ -120,16 +124,16 @@ extension MainViewController {
         NSLayoutConstraint.activate([
             addMemberButton.centerYAnchor.constraint(equalTo: familyTableLabel.centerYAnchor),
             addMemberButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
-            addMemberButton.heightAnchor.constraint(equalToConstant: 24),
-            addMemberButton.widthAnchor.constraint(equalToConstant: 24),
+            addMemberButton.heightAnchor.constraint(equalToConstant: touchAreaSize),
+            addMemberButton.widthAnchor.constraint(equalToConstant: touchAreaSize),
         ])
         
         settingButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             settingButton.centerYAnchor.constraint(equalTo: todayQuestionView.todayTitleLabel.centerYAnchor),
             settingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
-            settingButton.heightAnchor.constraint(equalToConstant: 24),
-            settingButton.widthAnchor.constraint(equalToConstant: 24),
+            settingButton.heightAnchor.constraint(equalToConstant: touchAreaSize),
+            settingButton.widthAnchor.constraint(equalToConstant: touchAreaSize),
         ])
     }
 }

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -60,7 +60,7 @@ final class MainViewController: UIViewController {
     }
     
     private func setButtonMenu() {
-        let notiSetting = UIAction(title: "알림 설정", image: ImageLiterals.icBell) { _ in
+        let notiSetting = UIAction(title: "알림 허용 설정", image: ImageLiterals.icBell) { _ in
             guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
             if UIApplication.shared.canOpenURL(url) {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -34,19 +34,6 @@ final class MainViewController: UIViewController {
     private lazy var settingButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.icSetting, for: .normal)
-        let notiSetting = UIAction(title: "알림 설정") { _ in
-            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-            if UIApplication.shared.canOpenURL(url) {
-                UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            }
-        }
-        let cycleSetting = UIAction(title: "알림 주기 설정") { [weak self] _ in
-            let notiSettingViewController = OnboardingTwoViewController()
-            let notificationCycle = UserDefaults.standard.userNotificationCycle
-            notiSettingViewController.cycleViewMode = .setting(cycle: Double(notificationCycle ?? 3))
-            self?.navigationController?.pushViewController(notiSettingViewController, animated: true)
-        }
-        button.menu = UIMenu(title: "설정", image: nil, identifier: nil, options: .displayInline , children: [notiSetting, cycleSetting])
         button.showsMenuAsPrimaryAction = true
         return button
     }()
@@ -71,6 +58,22 @@ final class MainViewController: UIViewController {
         familyTableView.delegate = self
         familyTableView.dataSource = self
     }
+    
+    private func setButtonMenu() {
+        let notiSetting = UIAction(title: "알림 설정") { _ in
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            if UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }
+        let cycleSetting = UIAction(title: "알림 주기 설정") { [weak self] _ in
+            let notiSettingViewController = OnboardingTwoViewController()
+            let notificationCycle = UserDefaults.standard.userNotificationCycle
+            notiSettingViewController.cycleViewMode = .setting(cycle: Double(notificationCycle ?? 3))
+            self?.navigationController?.pushViewController(notiSettingViewController, animated: true)
+        }
+        settingButton.menu = UIMenu(title: "설정", image: nil, identifier: nil, options: .displayInline , children: [notiSetting, cycleSetting])
+    }
 }
 
 extension MainViewController {
@@ -78,6 +81,7 @@ extension MainViewController {
     private func configureUI() {
         view.backgroundColor = .systemBackground
         familyTableView.backgroundColor = .systemBackground
+        setButtonMenu()
     }
     private func configureAddSubViews() {
         view.addSubviews(todayQuestionView,

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -28,7 +28,7 @@ final class MainViewController: UIViewController {
     private lazy var addMemberButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.icPlus, for: .normal)
-        button.addTarget(self, action: #selector(tapAddButton(_:)), for: .touchUpInside)
+        button.addTarget(self, action: #selector(tapAddButton), for: .touchUpInside)
         return button
     }()
     private let settingButton: UIButton = {
@@ -47,7 +47,7 @@ final class MainViewController: UIViewController {
     }
     
     // MARK: - Selector
-    @objc private func tapAddButton(_ sender: Any) {
+    @objc private func tapAddButton() {
         let addingViewController = AddingViewController()
         navigationController?.pushViewController(addingViewController, animated: true)
     }

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -41,7 +41,6 @@ final class MainViewController: UIViewController {
             }
         }
         let cycleSetting = UIAction(title: "알림 주기 설정") { [weak self] _ in
-            // TODO: 세팅에서 주기 설정 페이지 이동, 온보딩에서 주기 설정 페이지 각각에 따라 다른 처리 해줘야한다
             let notiSettingViewController = OnboardingTwoViewController()
             let notificationCycle = UserDefaults.standard.userNotificationCycle
             notiSettingViewController.cycleViewMode = .setting(cycle: Double(notificationCycle ?? 3))

--- a/AMaDda/Screens/Main/Views/TodayQuestionView.swift
+++ b/AMaDda/Screens/Main/Views/TodayQuestionView.swift
@@ -11,7 +11,7 @@ import UIKit
 final class TodayQuestionView: UIView {
     private let todayQuestionData = TodayQuestionMockData.mockData
     // MARK: - property
-    private let todayTitleLabel: UILabel = {
+    let todayTitleLabel: UILabel = {
         let label = UILabel()
         label.text = "오늘의 가족 Question"
         label.font = UIFont.systemFont(ofSize: 22, weight: .bold)

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -7,9 +7,15 @@
 
 import UIKit
 
+enum CycleViewMode {
+    case onboarding
+    case setting(cycle: Double)
+}
+
 class OnboardingTwoViewController: UIViewController {
     
     var notificationCount = 3
+    var cycleViewMode = CycleViewMode.onboarding
     
     // MARK: Properties
     private let onboardingTwoTitleLabel: UILabel = {
@@ -60,9 +66,18 @@ class OnboardingTwoViewController: UIViewController {
         configureConstraints()
     }
     
+    // MARK: - Functions
+    private func checkCycleViewMode() {
+        if case let CycleViewMode.setting(cycle) = cycleViewMode {
+            onboardingStepper.value = cycle
+            showNotificationLabel.text = "\(Int(cycle))일"
+        }
+    }
+    
     // MARK: Configures
     private func configureUI() {
         view.backgroundColor = .systemBackground
+        checkCycleViewMode()
     }
     
     private func configureAddSubView() {

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 enum CycleViewMode {
     case onboarding
-    case setting(cycle: Double)
+    case setting(cycle: Int)
 }
 
 class OnboardingTwoViewController: UIViewController {
@@ -69,8 +69,8 @@ class OnboardingTwoViewController: UIViewController {
     // MARK: - Functions
     private func checkCycleViewMode() {
         if case let CycleViewMode.setting(cycle) = cycleViewMode {
-            onboardingStepper.value = cycle
-            showNotificationLabel.text = "\(Int(cycle))일"
+            onboardingStepper.value = Double(cycle)
+            showNotificationLabel.text = "\(cycle)일"
         }
     }
     


### PR DESCRIPTION
# 이슈 번호
🔒 Close #54 

## 구현 / 변경 사항 이유
![Simulator Screen Recording - iPhone 13 - 2022-07-24 at 13 49 21](https://user-images.githubusercontent.com/26588989/180632979-8c81330d-713f-4f5b-86d1-251ddd26fa60.gif)![Simulator Screen Recording - iPhone 13 - 2022-07-24 at 13 48 50](https://user-images.githubusercontent.com/26588989/180632975-9b1e945b-780d-44ed-97c8-fec73e54a47e.gif)

### 구현
main view에 setting을 담당하는 pull down button 생성
main view에 addView로 연결하는 button 생성

### 변경 내용
-todayQuestionView의 todayTitleLabel의 접근제어자 private을 삭제 ( setting button의 y좌표를 해당 label과 맞춰주기 위해 접근이 필요)
- OnboardingTwoViewController에 cycleViewMode를 나타내는 enum 생성 ( 온보딩에서 해당 페이지를 접근하는지, setting에서 접근하는지에 따라 해줘야하는 일이 다르기 때문에 분기하기 위해서 enum 생성 )
- setting에서 OnboardingTweViewcontroller로 접근하는 경우 기존의 notificationCycle 값을 전달

## 리뷰 포인트
```swift
let notiSettingViewController = OnboardingTwoViewController()
let notificationCycle = UserDefaults.standard.userNotificationCycle
 notiSettingViewController.cycleViewMode = .setting(cycle: Double(notificationCycle ?? 3))
self?.navigationController?.pushViewController(notiSettingViewController, animated: true)
```
알림 주기 체크 페이지로 이동시키는 로직에서 userDefaults 값을 받아올 때 optional binding을 사용하지 않고 nil coalescing operator를 사용하였습니다.
해당 페이지로 이동하는 상황은 userNotificationCycle이 무조건 정해져있는 상황이기는 하지만, 혹시나 앱의 오류 때문에 값을 받아오지 못하는 경우 optional binding을 하여 else 구문으로 return을 하게되면 해당 페이지로 이동을 하지 못하는 오류가 발생한다고 생각합니다.
유저에게 어떠한 경우에도 앱의 오류의 경험을 제공해서는 안된다고 생각하기 때문에 최대한 문제를 주지 않도록 기본 stepper값인 3의 값을 nil coalescing operator를 통해 제공하였습니다.
해당 로직과 관련하여 더 좋은 방법이 있다면 조언 부탁드립니다.

## 추후 진행할 사항
- [ ] OnboardingTwoViewController에서 cycleViewMode에 따른 button action 처리

## References
- https://zeddios.tistory.com/1098
- https://baked-corn.tistory.com/130

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?


## 제안
한가지 제안하고 싶은게 있습니다 @Gobans 
MainViewController의 104번 줄을 보면
```swift
todayQuestionView.configureConstraintsTodayQuestionView()
```
이렇게 되어있는데, 이 부분은 todayQuestionView 내부의 autoLayout을 잡아주는 부분이라고 여겨집니다.
그래서 해당 configureConstraints~ 함수를 todayQustionView의 init 함수에 작성해주는건 어떨까요?
view Controller에서 해당 뷰의 autolayout을 잡는 코드가 있다보니 약간의 혼동이 생기는 것 같습니다 
