### PR TITLE
[FEAT] 오늘의 질문 매일마다 갱신

### DIFF
--- a/AMaDda.xcodeproj/project.pbxproj
+++ b/AMaDda.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		91804FAB288A737F0038A2A2 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91804FAA288A737F0038A2A2 /* Date+Extension.swift */; };
 		918BAFFC2886ED94002F94DB /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */; };
 		91DC448E288E80E7002F0D46 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DC448D288E80E7002F0D46 /* TextLiteral.swift */; };
+		91DC4490288E8628002F0D46 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DC448F288E8628002F0D46 /* Collection+Extension.swift */; };
 		91F1488728859FD1005A45E1 /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F1488628859FD1005A45E1 /* UserNotificationManager.swift */; };
 		91FD28A82884F32700F49D20 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A72884F32700F49D20 /* MainViewController.swift */; };
 		91FD28AA2884F3E500F49D20 /* TodayQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */; };
@@ -58,6 +59,7 @@
 		91804FAA288A737F0038A2A2 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		91DC448D288E80E7002F0D46 /* TextLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLiteral.swift; sourceTree = "<group>"; };
+		91DC448F288E8628002F0D46 /* Collection+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extension.swift"; sourceTree = "<group>"; };
 		91F1488628859FD1005A45E1 /* UserNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationManager.swift; sourceTree = "<group>"; };
 		91FD28A72884F32700F49D20 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionView.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */,
 				3E98E8E4288652DF001153E4 /* NSObject+Extension.swift */,
 				91804FAA288A737F0038A2A2 /* Date+Extension.swift */,
+				91DC448F288E8628002F0D46 /* Collection+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 				91DC448E288E80E7002F0D46 /* TextLiteral.swift in Sources */,
 				3E15D66F2884FB8000570DD7 /* FamilyTableCell.swift in Sources */,
 				3E622CEE28803971006A921C /* AppDelegate.swift in Sources */,
+				91DC4490288E8628002F0D46 /* Collection+Extension.swift in Sources */,
 				3E98E8E5288652DF001153E4 /* NSObject+Extension.swift in Sources */,
 				91FD28AA2884F3E500F49D20 /* TodayQuestionView.swift in Sources */,
 				D7ADBBA72883D520004BB5FE /* CommonButton.swift in Sources */,

--- a/AMaDda.xcodeproj/project.pbxproj
+++ b/AMaDda.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		91715FF62888019700A780B7 /* UserDefaultsStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91715FF52888019700A780B7 /* UserDefaultsStateManager.swift */; };
 		91804FAB288A737F0038A2A2 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91804FAA288A737F0038A2A2 /* Date+Extension.swift */; };
 		918BAFFC2886ED94002F94DB /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */; };
+		91DC448E288E80E7002F0D46 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DC448D288E80E7002F0D46 /* TextLiteral.swift */; };
 		91F1488728859FD1005A45E1 /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F1488628859FD1005A45E1 /* UserNotificationManager.swift */; };
 		91FD28A82884F32700F49D20 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A72884F32700F49D20 /* MainViewController.swift */; };
 		91FD28AA2884F3E500F49D20 /* TodayQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */; };
@@ -56,6 +57,7 @@
 		91715FF52888019700A780B7 /* UserDefaultsStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStateManager.swift; sourceTree = "<group>"; };
 		91804FAA288A737F0038A2A2 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
+		91DC448D288E80E7002F0D46 /* TextLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLiteral.swift; sourceTree = "<group>"; };
 		91F1488628859FD1005A45E1 /* UserNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationManager.swift; sourceTree = "<group>"; };
 		91FD28A72884F32700F49D20 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionView.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 			children = (
 				91FD28B42884F55C00F49D20 /* Size.swift */,
 				D72A1DFF28854C9C0058EE12 /* ImageLiteral.swift */,
+				91DC448D288E80E7002F0D46 /* TextLiteral.swift */,
 			);
 			path = Literal;
 			sourceTree = "<group>";
@@ -356,6 +359,7 @@
 				D72A1E0028854C9C0058EE12 /* ImageLiteral.swift in Sources */,
 				91804FAB288A737F0038A2A2 /* Date+Extension.swift in Sources */,
 				91FD28B82884F70A00F49D20 /* FontsPlaceHolder.swift in Sources */,
+				91DC448E288E80E7002F0D46 /* TextLiteral.swift in Sources */,
 				3E15D66F2884FB8000570DD7 /* FamilyTableCell.swift in Sources */,
 				3E622CEE28803971006A921C /* AppDelegate.swift in Sources */,
 				3E98E8E5288652DF001153E4 /* NSObject+Extension.swift in Sources */,

--- a/AMaDda/Global/Extension/Collection+Extension.swift
+++ b/AMaDda/Global/Extension/Collection+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  Collection+Extension.swift
+//  AMaDda
+//
+//  Created by Lee Myeonghwan on 2022/07/25.
+//
+
+import Foundation
+
+extension Collection {
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/AMaDda/Global/Extension/UserDefaults+Extension.swift
+++ b/AMaDda/Global/Extension/UserDefaults+Extension.swift
@@ -33,9 +33,9 @@ extension UserDefaults {
             }
             return enteredDate
         }
-         set {
-             UserDefaults.standard.set(newValue, forKey: "finalEnteredDate")
-         }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "finalEnteredDate")
+        }
     }
     var questionIndex: Int {
         get {

--- a/AMaDda/Global/Extension/UserDefaults+Extension.swift
+++ b/AMaDda/Global/Extension/UserDefaults+Extension.swift
@@ -37,4 +37,13 @@ extension UserDefaults {
              UserDefaults.standard.set(newValue, forKey: "finalEnteredDate")
          }
     }
+    var questionIndex: Int {
+        get {
+            guard let index = UserDefaults.standard.value(forKey: "questionIndex") as? Int else { return 0 }
+            return index
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "questionIndex")
+        }
+    }
 }

--- a/AMaDda/Global/Extension/UserDefaults+Extension.swift
+++ b/AMaDda/Global/Extension/UserDefaults+Extension.swift
@@ -10,40 +10,40 @@ import Foundation
 extension UserDefaults {
     var userNotificationCycle: Int? {
         get {
-            guard let count = UserDefaults.standard.value(forKey: "userNotificationCycle") as? Int else { return nil }
+            guard let count = UserDefaults.standard.value(forKey: TextLiteral.userNotificationCycle) as? Int else { return nil }
             return count
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "userNotificationCycle")
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.userNotificationCycle)
         }
     }
     var finalContactDiffDay: Int? {
         get {
-            guard let diff = UserDefaults.standard.value(forKey: "finalContactDiffDay") as? Int else { return nil }
+            guard let diff = UserDefaults.standard.value(forKey: TextLiteral.finalContactDiffDay) as? Int else { return nil }
             return diff
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "finalContactDiffDay")
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.finalContactDiffDay)
         }
     }
     var finalEnteredDate: Date? {
         get {
-            guard let enteredDate = UserDefaults.standard.value(forKey: "finalEnteredDate") as? Date else {
+            guard let enteredDate = UserDefaults.standard.value(forKey: TextLiteral.finalEnteredDate) as? Date else {
                 return nil
             }
             return enteredDate
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "finalEnteredDate")
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.finalEnteredDate)
         }
     }
     var questionIndex: Int {
         get {
-            guard let index = UserDefaults.standard.value(forKey: "questionIndex") as? Int else { return 0 }
+            guard let index = UserDefaults.standard.value(forKey: TextLiteral.questionIndex) as? Int else { return 0 }
             return index
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "questionIndex")
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.questionIndex)
         }
     }
 }

--- a/AMaDda/Global/Literal/TextLiteral.swift
+++ b/AMaDda/Global/Literal/TextLiteral.swift
@@ -1,0 +1,16 @@
+//
+//  TextLiteral.swift
+//  AMaDda
+//
+//  Created by Lee Myeonghwan on 2022/07/25.
+//
+
+import Foundation
+
+enum TextLiteral {
+    // MARK: - UserDefaults
+    static var userNotificationCycle: String { return "userNotificationCycle"}
+    static var finalContactDiffDay: String { return "finalContactDiffDay"}
+    static var finalEnteredDate: String { return "finalEnteredDate"}
+    static var questionIndex: String { return "questionIndex"}
+}

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -11,7 +11,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -33,6 +32,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        UserDefaultsStateManager.userEnteredApp()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -33,7 +33,7 @@ final class UserDefaultsStateManager {
     }
     static private func updateTodayQuestion() {
         var questionIndex = UserDefaults.standard.questionIndex
-        if questionIndex >= TodayQuestionMockData.mockData.count {
+        if questionIndex >= TodayQuestionMockData.mockData.count - 1 {
             questionIndex = 0
         } else {
             questionIndex += 1

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -35,10 +35,9 @@ final class UserDefaultsStateManager {
         var questionIndex = UserDefaults.standard.questionIndex
         if questionIndex >= TodayQuestionMockData.mockData.count {
             questionIndex = 0
-            UserDefaults.standard.questionIndex = questionIndex
-            return
+        } else {
+            questionIndex += 1
         }
-        questionIndex += 1
         todayQuestionDelegate?.changeTodayQuestion(questionIndex)
         UserDefaults.standard.questionIndex = questionIndex
     }

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
+protocol TodayQuestionDelegate: AnyObject {
+    func changeTodayQuestion(_ index: Int)
+}
+
 final class UserDefaultsStateManager {
+    static var todayQuestionDelegate: TodayQuestionDelegate?
     static func userEnteredApp() {
         let today = Date().convertedKoreaDate
         guard let finalEnteredDate = UserDefaults.standard.finalEnteredDate else {
@@ -18,11 +23,23 @@ final class UserDefaultsStateManager {
             return
         }
         updateFinalContactDiffDay(offsetDay)
+        updateTodayQuestion()
         UserDefaults.standard.finalEnteredDate = today
     }
     static private func updateFinalContactDiffDay(_ offsetDay: Int) {
         guard var finalContactDiffDay = UserDefaults.standard.finalContactDiffDay else { return }
         finalContactDiffDay += offsetDay
         UserDefaults.standard.finalContactDiffDay = finalContactDiffDay
+    }
+    static private func updateTodayQuestion() {
+        var questionIndex = UserDefaults.standard.questionIndex
+        if questionIndex >= TodayQuestionMockData.mockData.count {
+            questionIndex = 0
+            UserDefaults.standard.questionIndex = questionIndex
+            return
+        }
+        questionIndex += 1
+        todayQuestionDelegate?.changeTodayQuestion(questionIndex)
+        UserDefaults.standard.questionIndex = questionIndex
     }
 }

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -91,7 +91,6 @@ extension MainViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-
     }
 }
 

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -110,7 +110,7 @@ extension MainViewController: UITableViewDataSource {
 
 extension MainViewController: TodayQuestionDelegate {
     func changeTodayQuestion(_ index: Int) {
-        let todayQuestion = todayQuestionData[index].question
-        todayQuestionView.todayCardQuestionLabel.text = todayQuestion
+        guard let todayQuestion = todayQuestionData[safe: index] else { return }
+        todayQuestionView.todayCardQuestionLabel.text = todayQuestion.question
     }
 }

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -10,8 +10,9 @@ import UIKit
 
 final class MainViewController: UIViewController {
     private var familyMembers = FamilyMemberMockData.familyMemberData
-    
+    private let todayQuestionData = TodayQuestionMockData.mockData
     private let todayQuestionView = TodayQuestionView()
+    private let todayQuestionIndex = UserDefaults.standard.questionIndex
     
     private let familyTableLabel: UILabel = {
         let label = UILabel()
@@ -32,10 +33,12 @@ final class MainViewController: UIViewController {
         configureAddSubViews()
         configureConstraints()
         setUpDelegate()
+        changeTodayQuestion(todayQuestionIndex)
     }
     
     // MARK: - functions
     private func setUpDelegate() {
+        UserDefaultsStateManager.todayQuestionDelegate = self
         familyTableView.delegate = self
         familyTableView.dataSource = self
     }
@@ -103,5 +106,12 @@ extension MainViewController: UITableViewDataSource {
         cell.item = item
         cell.selectionStyle = .none
         return cell
+    }
+}
+
+extension MainViewController: TodayQuestionDelegate {
+    func changeTodayQuestion(_ index: Int) {
+        let todayQuestion = todayQuestionData[index].question
+        todayQuestionView.todayCardQuestionLabel.text = todayQuestion
     }
 }

--- a/AMaDda/Screens/Main/Views/TodayQuestionView.swift
+++ b/AMaDda/Screens/Main/Views/TodayQuestionView.swift
@@ -17,7 +17,7 @@ final class TodayQuestionView: UIView {
         return label
     }()
     private let todayCardView = UIView()
-    var todayCardQuestionLabel: UILabel = {
+    let todayCardQuestionLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
         label.numberOfLines = 0

--- a/AMaDda/Screens/Main/Views/TodayQuestionView.swift
+++ b/AMaDda/Screens/Main/Views/TodayQuestionView.swift
@@ -9,7 +9,6 @@ import Foundation
 import UIKit
 
 final class TodayQuestionView: UIView {
-    private let todayQuestionData = TodayQuestionMockData.mockData
     // MARK: - property
     private let todayTitleLabel: UILabel = {
         let label = UILabel()
@@ -23,10 +22,8 @@ final class TodayQuestionView: UIView {
         view.backgroundColor = UIColor.cardBackgroundColor
         return view
     }()
-    private lazy var todayCardQuestionLabel: UILabel = {
+    var todayCardQuestionLabel: UILabel = {
         let label = UILabel()
-        let randomQuestion = chooseRandomQuestion()
-        label.text = randomQuestion
         return label
     }()
 }
@@ -54,10 +51,5 @@ extension TodayQuestionView {
             todayCardQuestionLabel.centerYAnchor.constraint(equalTo: todayCardView.centerYAnchor),
             todayCardQuestionLabel.centerXAnchor.constraint(equalTo: todayCardView.centerXAnchor)
         ])
-    }
-    // MARK: - function
-    private func chooseRandomQuestion() -> String {
-        guard let todayQuestion = todayQuestionData.randomElement() else { return "Question이 없습니다."}
-        return todayQuestion.question
     }
 }

--- a/AMaDda/Screens/Main/Views/TodayQuestionView.swift
+++ b/AMaDda/Screens/Main/Views/TodayQuestionView.swift
@@ -16,10 +16,7 @@ final class TodayQuestionView: UIView {
         label.font = UIFont.systemFont(ofSize: 28, weight: .bold)
         return label
     }()
-    private let todayCardView: UIView = {
-        let view = UIView()
-        return view
-    }()
+    private let todayCardView = UIView()
     var todayCardQuestionLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 18, weight: .bold)


### PR DESCRIPTION
# 이슈 번호
🔒 Close #11 

## 구현 / 변경 사항 이유

<!-- 구현 / 변경한 내용과 그 이유를 적어주세요. -->
- 유저가 다른날에 접속했을때 질문을 갱신하기위해 UserDefaultsStateManager.userEnteredApp 메소드 안에서 실행되도록 구현하였습니다.
- 변경과 동시에 TodayQuestionView의 질문 라벨을 바꿔줘야하기 때문에 todayQuestionDelegate를 UserDefaultsStateManager 안에 프로퍼티로 가지고있도록 하였습니다.

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

## 리뷰 포인트
- @YebinKim 
- delegate 패턴을 처음 써보는것이라 구현이 잘 된게 맞을지 궁금합니다!
- TodayQuestionDelegate protocol이 UserDefaultsStateManager에 있는게 좋을까요 MainViewController에 있는게 좋을까요?

## 추후 진행할 사항

- [ ] 임시 앱 아이콘 추가
- [ ] 알림 메시지 촬영

## References

- https://i-colours-u.tistory.com/6

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?
