### PR TITLE
[FEAT] empty table view

### DIFF
--- a/AMaDda.xcodeproj/project.pbxproj
+++ b/AMaDda.xcodeproj/project.pbxproj
@@ -15,11 +15,11 @@
 		3E622CF528803971006A921C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF328803971006A921C /* Main.storyboard */; };
 		3E622CF728803972006A921C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF628803972006A921C /* Assets.xcassets */; };
 		3E622CFA28803972006A921C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3E622CF828803972006A921C /* LaunchScreen.storyboard */; };
-		918BAFFC2886ED94002F94DB /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */; };
-		91F1488728859FD1005A45E1 /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F1488628859FD1005A45E1 /* UserNotificationManager.swift */; };
 		3E98E8E5288652DF001153E4 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E98E8E4288652DF001153E4 /* NSObject+Extension.swift */; };
 		595E3B41288577D60036B677 /* OnboardingOneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595E3B40288577D60036B677 /* OnboardingOneViewController.swift */; };
 		59F2584228868FA9003BC6ED /* OnboardingTwoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F2584128868FA9003BC6ED /* OnboardingTwoViewController.swift */; };
+		918BAFFC2886ED94002F94DB /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */; };
+		91F1488728859FD1005A45E1 /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F1488628859FD1005A45E1 /* UserNotificationManager.swift */; };
 		91FD28A82884F32700F49D20 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A72884F32700F49D20 /* MainViewController.swift */; };
 		91FD28AA2884F3E500F49D20 /* TodayQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */; };
 		91FD28AD2884F43A00F49D20 /* TodayQuestionMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FD28AC2884F43A00F49D20 /* TodayQuestionMockData.swift */; };
@@ -34,6 +34,7 @@
 		E6278AD928843F8E00DC0CB0 /* ProfileModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6278AD828843F8E00DC0CB0 /* ProfileModalViewController.swift */; };
 		E6278ADD2884412D00DC0CB0 /* ProfileModalCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6278ADC2884412D00DC0CB0 /* ProfileModalCell.swift */; };
 		E6278AE52884FCF500DC0CB0 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */; };
+		E67D4646288D21F400083187 /* EmptyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67D4645288D21F400083187 /* EmptyTableViewCell.swift */; };
 		E6DCDBDB288652CF001D4F67 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DCDBDA288652CF001D4F67 /* UIViewController+Extension.swift */; };
 /* End PBXBuildFile section */
 
@@ -48,11 +49,11 @@
 		3E622CF628803972006A921C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3E622CF928803972006A921C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3E622CFB28803972006A921C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
-		91F1488628859FD1005A45E1 /* UserNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationManager.swift; sourceTree = "<group>"; };
 		3E98E8E4288652DF001153E4 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		595E3B40288577D60036B677 /* OnboardingOneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOneViewController.swift; sourceTree = "<group>"; };
 		59F2584128868FA9003BC6ED /* OnboardingTwoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTwoViewController.swift; sourceTree = "<group>"; };
+		918BAFFB2886ED94002F94DB /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
+		91F1488628859FD1005A45E1 /* UserNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationManager.swift; sourceTree = "<group>"; };
 		91FD28A72884F32700F49D20 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionView.swift; sourceTree = "<group>"; };
 		91FD28AC2884F43A00F49D20 /* TodayQuestionMockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayQuestionMockData.swift; sourceTree = "<group>"; };
@@ -67,6 +68,7 @@
 		E6278AD828843F8E00DC0CB0 /* ProfileModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileModalViewController.swift; sourceTree = "<group>"; };
 		E6278ADC2884412D00DC0CB0 /* ProfileModalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileModalCell.swift; sourceTree = "<group>"; };
 		E6278AE42884FCF500DC0CB0 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		E67D4645288D21F400083187 /* EmptyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTableViewCell.swift; sourceTree = "<group>"; };
 		E6DCDBDA288652CF001D4F67 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -182,6 +184,7 @@
 			children = (
 				91FD28A92884F3E500F49D20 /* TodayQuestionView.swift */,
 				3E15D66E2884FB8000570DD7 /* FamilyTableCell.swift */,
+				E67D4645288D21F400083187 /* EmptyTableViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -365,6 +368,7 @@
 				3E15D6732884FC1F00570DD7 /* FamilyMemberMockData.swift in Sources */,
 				91FD28A82884F32700F49D20 /* MainViewController.swift in Sources */,
 				D72A1DFE28854AA10058EE12 /* AddingViewController.swift in Sources */,
+				E67D4646288D21F400083187 /* EmptyTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AMaDda/Model/FamilyMemberMockData.swift
+++ b/AMaDda/Model/FamilyMemberMockData.swift
@@ -24,7 +24,7 @@ final class FamilyMemberMockData {
         
         guard let someDateTime = calendar.date(from: dateComponents) else { fatalError() }
         guard let someDateTime1 = calendar.date(from: dateComponents1) else { fatalError() }
-        var data = [
+        var data: [FamilyMemberData] = [
             FamilyMemberData(name: "엄마", characterImageName: "Character2", lastContactDate: someDateTime),
             FamilyMemberData(name: "아빠", characterImageName: "Character2", lastContactDate: someDateTime1),
         ]

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -9,16 +9,16 @@ import Foundation
 import UIKit
 
 final class MainViewController: UIViewController {
-    private var familyMemberCount = 0
     private var familyMembers: [FamilyMemberData] = {
         UserDefaults.standard.familyMembers = FamilyMemberMockData.familyMemberData
 //        guard let familyMembers = UserDefaults.standard.familyMembers else {
 //            print("아직 추가한 가족 멤버 없음")
 //            return nil
 //        }
-        let familyMembers = UserDefaults.standard.familyMembers
+        let familyMembers: [FamilyMemberData] = UserDefaults.standard.familyMembers
         return familyMembers
     }()
+    private lazy var familyMemberCount = familyMembers.count
     private let todayQuestionView = TodayQuestionView()
     
     private let touchAreaSize: CGFloat = 44
@@ -32,7 +32,6 @@ final class MainViewController: UIViewController {
         let tableView = UITableView()
         tableView.register(FamilyTableCell.self, forCellReuseIdentifier: FamilyTableCell.className)
         tableView.register(EmptyTableViewCell.self, forCellReuseIdentifier: EmptyTableViewCell.className)
-        tableView.separatorStyle = .none
         tableView.showsVerticalScrollIndicator = false
         return tableView
     }()
@@ -173,6 +172,7 @@ extension MainViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch familyMemberCount {
         case 0:
+            tableView.separatorStyle = .none
             return 1
         default:
             return familyMembers.count

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -10,8 +10,12 @@ import UIKit
 
 final class MainViewController: UIViewController {
     //private var familyMembers = FamilyMemberMockData.familyMemberData
-    private var familyMembers: [FamilyMemberData] = []
-    
+    private var familyMembers = Array<FamilyMemberData>() {
+        didSet {
+            familyMemberCount = familyMembers.count
+        }
+    }
+    private var familyMemberCount = 0
     private let todayQuestionView = TodayQuestionView()
     
     private let familyTableLabel: UILabel = {
@@ -85,22 +89,22 @@ extension MainViewController {
 
 extension MainViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        switch familyMembers.count {
+        switch familyMemberCount {
         case 0:
             return familyTableView.frame.height
         default:
             return 140
         }
     }
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-
     }
 }
 
 extension MainViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch familyMembers.count {
+        switch familyMemberCount {
         case 0:
             return 1
         default:
@@ -109,9 +113,11 @@ extension MainViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        switch familyMembers.count {
+        switch familyMemberCount {
         case 0:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: EmptyTableViewCell.className, for: indexPath) as? EmptyTableViewCell else { fatalError() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: EmptyTableViewCell.className, for: indexPath) as? EmptyTableViewCell else {
+                return UITableViewCell()
+            }
             return cell
         default:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: FamilyTableCell.className, for: indexPath) as? FamilyTableCell else { fatalError() }
@@ -119,7 +125,6 @@ extension MainViewController: UITableViewDataSource {
             cell.item = item
             cell.selectionStyle = .none
             return cell
-
         }
     }
 }

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -13,6 +13,7 @@ final class MainViewController: UIViewController {
     private var familyMembers = Array<FamilyMemberData>() {
         didSet {
             familyMemberCount = familyMembers.count
+            familyTableView.reloadData()
         }
     }
     private var familyMemberCount = 0

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -9,7 +9,8 @@ import Foundation
 import UIKit
 
 final class MainViewController: UIViewController {
-    private var familyMembers = FamilyMemberMockData.familyMemberData
+    //private var familyMembers = FamilyMemberMockData.familyMemberData
+    private var familyMembers: [FamilyMemberData] = []
     
     private let todayQuestionView = TodayQuestionView()
     
@@ -22,6 +23,7 @@ final class MainViewController: UIViewController {
     private let familyTableView: UITableView = {
         let tableView = UITableView()
         tableView.register(FamilyTableCell.self, forCellReuseIdentifier: FamilyTableCell.className)
+        tableView.register(EmptyTableViewCell.self, forCellReuseIdentifier: EmptyTableViewCell.className)
         tableView.separatorStyle = .none
         return tableView
     }()
@@ -83,9 +85,13 @@ extension MainViewController {
 
 extension MainViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 140
+        switch familyMembers.count {
+        case 0:
+            return familyTableView.frame.height
+        default:
+            return 140
+        }
     }
-    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
@@ -94,14 +100,26 @@ extension MainViewController: UITableViewDelegate {
 
 extension MainViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return familyMembers.count
+        switch familyMembers.count {
+        case 0:
+            return 1
+        default:
+            return familyMembers.count
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: FamilyTableCell.className, for: indexPath) as? FamilyTableCell else { fatalError() }
-        let item = self.familyMembers[indexPath.row]
-        cell.item = item
-        cell.selectionStyle = .none
-        return cell
+        switch familyMembers.count {
+        case 0:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: EmptyTableViewCell.className, for: indexPath) as? EmptyTableViewCell else { fatalError() }
+            return cell
+        default:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: FamilyTableCell.className, for: indexPath) as? FamilyTableCell else { fatalError() }
+            let item = self.familyMembers[indexPath.row]
+            cell.item = item
+            cell.selectionStyle = .none
+            return cell
+
+        }
     }
 }

--- a/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
+++ b/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class EmptyTableViewCell: UITableViewCell {
+final class EmptyTableViewCell: UITableViewCell {
     
     // MARK: - Properties
     private let upperTableViewSpacing: CGFloat = 10

--- a/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
+++ b/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
@@ -20,7 +20,7 @@ final class EmptyTableViewCell: UITableViewCell {
     }()
     private let subTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "가족을 추가해볼까요?"
+        label.text = "+ 버튼을 눌러 가족을 추가해볼까요?"
         label.textAlignment = .center
         label.textColor = .gray
         return label

--- a/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
+++ b/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
@@ -1,0 +1,65 @@
+//
+//  EmptyTableViewCell.swift
+//  AMaDda
+//
+//  Created by sanghyo on 2022/07/24.
+//
+
+import UIKit
+
+class EmptyTableViewCell: UITableViewCell {
+    
+    // MARK: - Properties
+    private let upperTableViewSpacing: CGFloat = 10
+    private let mainTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "아직 기록중인 가족이 없어요"
+        label.textAlignment = .center
+        label.textColor = .gray
+        return label
+    }()
+    private let subTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "가족을 추가해볼까요?"
+        label.textAlignment = .center
+        label.textColor = .gray
+        return label
+    }()
+    private lazy var textStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [mainTitleLabel, subTitleLabel])
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.spacing = 10
+        return stackView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureUI()
+        configureAddSubviews()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Configure
+    private func configureUI() {
+        contentView.backgroundColor = .systemBackground
+    }
+    
+    private func configureAddSubviews() {
+        addSubviews(textStackView)
+    }
+    
+    private func configureConstraints() {
+        textStackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            textStackView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -upperTableViewSpacing),
+        ])
+        
+    }
+}

--- a/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
+++ b/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
@@ -51,14 +51,14 @@ final class EmptyTableViewCell: UITableViewCell {
     }
     
     private func configureAddSubviews() {
-        addSubviews(textStackView)
+        contentView.addSubviews(textStackView)
     }
     
     private func configureConstraints() {
         textStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            textStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            textStackView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -(upperTableViewSpacing / 2)),
+            textStackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            textStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -(upperTableViewSpacing / 2)),
         ])
         
     }

--- a/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
+++ b/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
@@ -58,7 +58,7 @@ final class EmptyTableViewCell: UITableViewCell {
         textStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             textStackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            textStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -(upperTableViewSpacing / 2)),
+            textStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -upperTableViewSpacing),
         ])
         
     }

--- a/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
+++ b/AMaDda/Screens/Main/Views/EmptyTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 final class EmptyTableViewCell: UITableViewCell {
     
     // MARK: - Properties
-    private let upperTableViewSpacing: CGFloat = 10
+    private let upperTableViewSpacing: CGFloat = 20
     private let mainTitleLabel: UILabel = {
         let label = UILabel()
         label.text = "아직 기록중인 가족이 없어요"
@@ -58,7 +58,7 @@ final class EmptyTableViewCell: UITableViewCell {
         textStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             textStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            textStackView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -upperTableViewSpacing),
+            textStackView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -(upperTableViewSpacing / 2)),
         ])
         
     }


### PR DESCRIPTION
# 이슈 번호
🔒 Close #55 

## 구현 / 변경 사항 이유
tableView의 empty cell을 만들었습니다.

<img width="250" src="https://user-images.githubusercontent.com/26588989/180639564-84072103-2539-4c30-afbf-e22ea2be693a.png">

## 리뷰 포인트
[해결]
empty 뷰 내부에 stackview를 넣는 과정에서 문제를 많이 겪었고 아직 해결하지 못한 상태입니다.
cell 내부에서 오토레이아웃을 잡을 때 contentView를 기준으로 잡아야한다고(?) 알고있는데 그렇게 했더니 오토 레이아웃이 원하는대로 되지 않고 다 이상하게 나와서 contentView없이 잡아놓은 상태입니다...
도와주세요... 잘 안되네요 ㅠㅠ
[이유]
addSubView의 위치를 contentView에 하지 않고 UIView에 해버리는 실수를 했습니다

## 추후 진행할 사항
현재 코드는 main의 table delegate와 datasource에 너무 많은 switch문을 넣었고, 의존성이 심해보입니다.
custom한 datasource와 delegate를 만들어 코드를 분리시켜보려 합니다.
개선할 때 참고할 링크는 아래 레퍼런스에 남겨두겠습니다

## References
- https://medium.com/@shaktiprakash09/custom-reusable-datasource-with-generic-data-model-in-ios-24d22d60e118
- https://medium.nextlevelswift.com/a-better-way-to-display-an-empty-indicator-when-the-table-view-data-source-is-empty-f3bc32f899ed

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

