### PR TITLE
[CHORE] TodayQuestionView 의 configure 메소드들을 mainViewController에서 분리

### DIFF
--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -107,7 +107,6 @@ extension MainViewController {
                          familyTableView,
                         addMemberButton,
                         settingButton)
-        todayQuestionView.configureAddSubViewsTodayQuestionView()
     }
     private func configureConstraints() {
         let safeAreaLayoutGuide = view.safeAreaLayoutGuide
@@ -119,7 +118,6 @@ extension MainViewController {
             todayQuestionView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
             todayQuestionView.heightAnchor.constraint(equalToConstant: 170),
         ])
-        todayQuestionView.configureConstraintsTodayQuestionView()
         
         familyTableLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/AMaDda/Screens/Main/Views/TodayQuestionView.swift
+++ b/AMaDda/Screens/Main/Views/TodayQuestionView.swift
@@ -17,7 +17,9 @@ final class TodayQuestionView: UIView {
         label.font = UIFont.systemFont(ofSize: 28, weight: .bold)
         return label
     }()
+    
     private let todayCardView = UIView()
+    
     private lazy var todayCardQuestionLabel: UILabel = {
         let label = UILabel()
         let randomQuestion = chooseRandomQuestion()
@@ -27,30 +29,43 @@ final class TodayQuestionView: UIView {
         label.textAlignment = .center
         return label
     }()
+    
     private let openingQuoteImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.openingQuote
         imageView.tintColor = .black
         return imageView
     }()
+    
     private let closingQuoteImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.closingQuote
         imageView.tintColor = .black
         return imageView
     }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureAddSubViewsTodayQuestionView()
+        configureConstraintsTodayQuestionView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
 }
 
 extension TodayQuestionView {
     // MARK: - configure
-    func configureAddSubViewsTodayQuestionView() {
+    private func configureAddSubViewsTodayQuestionView() {
         addSubviews(todayTitleLabel,
                     todayCardView,
                     todayCardQuestionLabel,
                     openingQuoteImageView,
                     closingQuoteImageView)
     }
-    func configureConstraintsTodayQuestionView() {
+    private func configureConstraintsTodayQuestionView() {
         todayTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             todayTitleLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),


### PR DESCRIPTION
# 이슈 번호
🔒 Close #70 

## 구현 / 변경 사항 이유

<!-- 구현 / 변경한 내용과 그 이유를 적어주세요. -->
- 굳이 mainViewController에서 TodayQuestionView의 configure를 호출할 이유가 없어서 변경하였습니다. 왜 이렇게 구현을 했을까요🧐

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

## 리뷰 포인트

- 👻

## 추후 진행할 사항

- [ ] 앱 아이콘 추가
- [ ] 앱 캐릭터 에셋 변경

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

