### PR TITLE
[HOTFIX] notificationCount setting view logic change

### DIFF
--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -83,8 +83,7 @@ final class MainViewController: UIViewController {
         }
         let cycleSetting = UIAction(title: "알림 주기 설정", image: ImageLiterals.icPencil) { [weak self] _ in
             let notiSettingViewController = OnboardingTwoViewController()
-            let notificationCycle = UserDefaults.standard.userNotificationCycle
-            notiSettingViewController.cycleViewMode = .setting(cycle: notificationCycle ?? 3)
+            notiSettingViewController.cycleViewMode = .setting
             self?.navigationController?.pushViewController(notiSettingViewController, animated: true)
         }
         settingButton.menu = UIMenu(options: .displayInline , children: [notiSetting, cycleSetting])

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum CycleViewMode: Equatable{
+enum CycleViewMode: Equatable {
     case onboarding, setting
 }
 

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -7,9 +7,8 @@
 
 import UIKit
 
-enum CycleViewMode {
-    case onboarding
-    case setting(cycle: Int)
+enum CycleViewMode: Equatable{
+    case onboarding, setting
 }
 
 final class OnboardingTwoViewController: UIViewController {
@@ -48,7 +47,8 @@ final class OnboardingTwoViewController: UIViewController {
     }()
     private lazy var startButton: CommonButton = {
         let button = CommonButton()
-        button.setTitle("시작하기", for: .normal)
+        let buttonTitle = cycleViewMode == .onboarding ? "시작하기" : "저장하기"
+        button.setTitle(buttonTitle, for: .normal)
         button.addTarget(self, action: #selector(didTapStartButton), for: .touchUpInside)
         return button
     }()
@@ -60,11 +60,16 @@ final class OnboardingTwoViewController: UIViewController {
     }
     
     @objc private func didTapStartButton() {
-        let mainVC = MainViewController()
-        navigationController?.pushViewController(mainVC, animated: true)
-        navigationController?.isNavigationBarHidden = true
+        switch cycleViewMode {
+        case .onboarding:
+            let mainVC = MainViewController()
+            navigationController?.pushViewController(mainVC, animated: true)
+            navigationController?.isNavigationBarHidden = true
+            UserDefaults.standard.checkedOnboarding = true
+        case .setting:
+            navigationController?.popViewController(animated: true)
+        }
         UserDefaults.standard.notificationCount = notificationCount
-        UserDefaults.standard.checkedOnboarding = true
     }
     
     // MARK: Life Cycle functions
@@ -77,9 +82,10 @@ final class OnboardingTwoViewController: UIViewController {
     
     // MARK: - Functions
     private func checkCycleViewMode() {
-        if case let CycleViewMode.setting(cycle) = cycleViewMode {
-            onboardingStepper.value = Double(cycle)
-            showNotificationLabel.text = "\(cycle)일"
+        if case CycleViewMode.setting = cycleViewMode {
+            guard let notificationCycle = UserDefaults.standard.notificationCount else { return }
+            onboardingStepper.value = Double(notificationCycle)
+            showNotificationLabel.text = "\(notificationCycle)일"
         }
     }
     


### PR DESCRIPTION
# 이슈 번호
🔒 Close #76 

## 구현 / 변경 사항 이유
onboardingTwoViewController가 setting에서 들어가는 상황, onboarding에서 들어가는 상황에 따라 다른 처리가 필요했습니다.
setting에서 값을 저장하면 userDefaults에 값이 저장되고 pop, onboarding에서는 기존처럼 push 되도록 했습니다.
![Simulator Screen Recording - iPhone 13 - 2022-07-25 at 18 25 56](https://user-images.githubusercontent.com/26588989/180745258-04f1e91f-ad98-49d7-98ce-6b99abf9d766.gif)

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

