### PR TITLE
[FEAT] 연락 목표 기능 구현과 알림기능 추가

### DIFF
--- a/AMaDda/Global/Extension/UserDefaults+Extension.swift
+++ b/AMaDda/Global/Extension/UserDefaults+Extension.swift
@@ -48,15 +48,6 @@ extension UserDefaults {
             UserDefaults.standard.set(newValue, forKey: TextLiteral.finalContactDiffDay)
         }
     }
-    var notificationCount: Int? {
-        get {
-            guard let count = UserDefaults.standard.value(forKey: TextLiteral.notificationCount) as? Int else { return nil }
-            return count
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: TextLiteral.notificationCount)
-        }
-    }
     // MARK: - question data
     var questionIndex: Int {
         get {

--- a/AMaDda/Global/Extension/UserDefaults+Extension.swift
+++ b/AMaDda/Global/Extension/UserDefaults+Extension.swift
@@ -8,6 +8,28 @@
 import Foundation
 
 extension UserDefaults {
+    // MARK: - User connect data
+    var finalEnteredDate: Date? {
+        get {
+            guard let enteredDate = UserDefaults.standard.value(forKey: TextLiteral.finalEnteredDate) as? Date else {
+                return nil
+            }
+            return enteredDate
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.finalEnteredDate)
+        }
+    }
+    var checkedOnboarding: Bool? {
+        get {
+            let count = UserDefaults.standard.bool(forKey: TextLiteral.checkedOnboarding)
+            return count
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.checkedOnboarding)
+        }
+    }
+    // MARK: - notification data
     var userNotificationCycle: Int? {
         get {
             guard let count = UserDefaults.standard.value(forKey: TextLiteral.userNotificationCycle) as? Int else { return nil }
@@ -26,7 +48,26 @@ extension UserDefaults {
             UserDefaults.standard.set(newValue, forKey: TextLiteral.finalContactDiffDay)
         }
     }
-    
+    var notificationCount: Int? {
+        get {
+            guard let count = UserDefaults.standard.value(forKey: TextLiteral.notificationCount) as? Int else { return nil }
+            return count
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.notificationCount)
+        }
+    }
+    // MARK: - question data
+    var questionIndex: Int {
+        get {
+            guard let index = UserDefaults.standard.value(forKey: TextLiteral.questionIndex) as? Int else { return 0 }
+            return index
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.questionIndex)
+        }
+    }
+    // MARK: - family data
     var familyMembers: [FamilyMemberData] {
         get {
             var members: [FamilyMemberData] = []
@@ -43,42 +84,32 @@ extension UserDefaults {
             UserDefaults.standard.set(try? PropertyListEncoder().encode(newValue), forKey: "familyMembers")
         }
     }
-    var finalEnteredDate: Date? {
+    // MARK: - Feedback data
+    var userContactGoal: Int {
         get {
-            guard let enteredDate = UserDefaults.standard.value(forKey: TextLiteral.finalEnteredDate) as? Date else {
-                return nil
-            }
-            return enteredDate
+            guard let goal = UserDefaults.standard.value(forKey: TextLiteral.userContactGoal) as? Int else { return 2 }
+            return goal
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: TextLiteral.finalEnteredDate)
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.userContactGoal)
         }
     }
-    var questionIndex: Int {
+    var contactGoalCount: Int {
         get {
-            guard let index = UserDefaults.standard.value(forKey: TextLiteral.questionIndex) as? Int else { return 0 }
-            return index
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: TextLiteral.questionIndex)
-        }
-    }
-    var notificationCount: Int? {
-        get {
-            guard let count = UserDefaults.standard.value(forKey: "notificationCount") as? Int else { return nil }
+            guard let count = UserDefaults.standard.value(forKey: TextLiteral.contactGoalCount) as? Int else { return 0 }
             return count
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "notificationCount")
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.contactGoalCount)
         }
     }
-    var checkedOnboarding: Bool? {
+    var isFeedbackPresented: Bool {
         get {
-            let count = UserDefaults.standard.bool(forKey: "checkedOnboarding")
-            return count
+            let check = UserDefaults.standard.bool(forKey: TextLiteral.isFeedbackPresented)
+            return check
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: "checkedOnboarding")
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.isFeedbackPresented)
         }
     }
 }

--- a/AMaDda/Global/Extension/UserDefaults+Extension.swift
+++ b/AMaDda/Global/Extension/UserDefaults+Extension.swift
@@ -94,13 +94,13 @@ extension UserDefaults {
             UserDefaults.standard.set(newValue, forKey: TextLiteral.contactGoalCount)
         }
     }
-    var isFeedbackPresented: Bool {
+    var isUserTodayContacted: Bool {
         get {
-            let check = UserDefaults.standard.bool(forKey: TextLiteral.isFeedbackPresented)
+            let check = UserDefaults.standard.bool(forKey: TextLiteral.isUserTodayContacted)
             return check
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: TextLiteral.isFeedbackPresented)
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.isUserTodayContacted)
         }
     }
 }

--- a/AMaDda/Global/Literal/TextLiteral.swift
+++ b/AMaDda/Global/Literal/TextLiteral.swift
@@ -16,5 +16,5 @@ enum TextLiteral {
     static var checkedOnboarding: String { return "checkedOnboarding"}
     static var userContactGoal: String { return "userContactGoal"}
     static var contactGoalCount: String { return "contactGoalCount"}
-    static var isFeedbackPresented: String { return "isFeedbackPresented"}
+    static var isUserTodayContacted: String { return "isUserTodayContacted"}
 }

--- a/AMaDda/Global/Literal/TextLiteral.swift
+++ b/AMaDda/Global/Literal/TextLiteral.swift
@@ -13,4 +13,9 @@ enum TextLiteral {
     static var finalContactDiffDay: String { return "finalContactDiffDay"}
     static var finalEnteredDate: String { return "finalEnteredDate"}
     static var questionIndex: String { return "questionIndex"}
+    static var notificationCount: String { return "notificationCount"}
+    static var checkedOnboarding: String { return "checkedOnboarding"}
+    static var userContactGoal: String { return "userContactGoal"}
+    static var contactGoalCount: String { return "contactGoalCount"}
+    static var isFeedbackPresented: String { return "isFeedbackPresented"}
 }

--- a/AMaDda/Global/Literal/TextLiteral.swift
+++ b/AMaDda/Global/Literal/TextLiteral.swift
@@ -13,7 +13,6 @@ enum TextLiteral {
     static var finalContactDiffDay: String { return "finalContactDiffDay"}
     static var finalEnteredDate: String { return "finalEnteredDate"}
     static var questionIndex: String { return "questionIndex"}
-    static var notificationCount: String { return "notificationCount"}
     static var checkedOnboarding: String { return "checkedOnboarding"}
     static var userContactGoal: String { return "userContactGoal"}
     static var contactGoalCount: String { return "contactGoalCount"}

--- a/AMaDda/Global/Supports/SceneDelegate.swift
+++ b/AMaDda/Global/Supports/SceneDelegate.swift
@@ -46,6 +46,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
+        userNotificationManager.addRequest()
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -71,7 +71,7 @@ final class UserDefaultsStateManager {
             UserDefaults.standard.isUserTodayContacted = true
         }
     }
-    func userChangeNotificationCycle(changedNotificationCycle: Int) {
+    func userChangeNotificationCycle(_ changedNotificationCycle: Int) {
         UserDefaults.standard.userNotificationCycle = changedNotificationCycle
         userNotificationManager.removeAllPendingRequest()
     }

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -78,7 +78,6 @@ final class UserDefaultsStateManager {
     }
     func userChangeNotificationCycle(changedNotificationCycle: Int) {
         UserDefaults.standard.userNotificationCycle = changedNotificationCycle
-        let userNotificationManager = UserNotificationManager()
         userNotificationManager.removeAllPendingRequest()
     }
 }

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -47,15 +47,13 @@ final class UserDefaultsStateManager {
         UserDefaults.standard.questionIndex = questionIndex
     }
     static private func updateContactGoalCount(_ offsetDay: Int) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "EEEEE"
-        dateFormatter.timeZone = TimeZone(abbreviation: "KST")
-        dateFormatter.locale = Locale(identifier: "ko_KR")
         var checkDate = Date().convertedKoreaDate
         var daysFromMonday = 0
-        while (dateFormatter.string(from: checkDate) != "월") {
+        var weekDay = Calendar.current.dateComponents([.weekday], from: checkDate).weekday ?? 2
+        while (weekDay != 2) {
             guard let pastDate = Calendar.current.date(byAdding: .day, value: -1, to: checkDate) else { return }
             checkDate = pastDate
+            weekDay = Calendar.current.dateComponents([.weekday], from: checkDate).weekday ?? 2
             daysFromMonday += 1
         }
         if daysFromMonday < offsetDay {

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -13,20 +13,23 @@ protocol TodayQuestionDelegate: AnyObject {
 
 final class UserDefaultsStateManager {
     static var todayQuestionDelegate: TodayQuestionDelegate?
+    let userNotificationManager = UserNotificationManager()
     static func userEnteredApp() {
         let today = Date().convertedKoreaDate
         guard let finalEnteredDate = UserDefaults.standard.finalEnteredDate else {
             UserDefaults.standard.finalEnteredDate = today
             return
         }
+        // MARK: - Today already Entered App
         guard let offsetDay = Date.daysFromToday(finalEnteredDate), offsetDay != 0 else {
             return
         }
+        // MARK: - First Entered App
         updateFinalContactDiffDay(offsetDay)
         updateTodayQuestion()
         updateContactGoalCount(offsetDay)
         UserDefaults.standard.finalEnteredDate = today
-        UserDefaults.standard.isFeedbackPresented = false
+        UserDefaults.standard.isUserTodayContacted = false
     }
     static private func updateFinalContactDiffDay(_ offsetDay: Int) {
         guard var finalContactDiffDay = UserDefaults.standard.finalContactDiffDay else { return }
@@ -59,11 +62,23 @@ final class UserDefaultsStateManager {
             UserDefaults.standard.contactGoalCount = 0
         }
     }
-    static func userContacted() {
+    static func userCreatedFamily() {
         UserDefaults.standard.finalContactDiffDay = 0
-        var contactGoalCount = UserDefaults.standard.contactGoalCount
-        contactGoalCount += 1
-        UserDefaults.standard.contactGoalCount = contactGoalCount
-        UserDefaults.standard.isFeedbackPresented = true
+    }
+    func userContacted() {
+        let isUserTodayContacted = UserDefaults.standard.isUserTodayContacted
+        if !isUserTodayContacted {
+            UserDefaults.standard.finalContactDiffDay = 0
+            var contactGoalCount = UserDefaults.standard.contactGoalCount
+            contactGoalCount += 1
+            UserDefaults.standard.contactGoalCount = contactGoalCount
+            userNotificationManager.updateRequestPendingContent()
+            UserDefaults.standard.isUserTodayContacted = true
+        }
+    }
+    func userChangeNotificationCycle(changedNotificationCycle: Int) {
+        UserDefaults.standard.userNotificationCycle = changedNotificationCycle
+        let userNotificationManager = UserNotificationManager()
+        userNotificationManager.removeAllPendingRequest()
     }
 }

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -59,4 +59,11 @@ final class UserDefaultsStateManager {
             UserDefaults.standard.contactGoalCount = 0
         }
     }
+    static func userContacted() {
+        UserDefaults.standard.finalContactDiffDay = 0
+        var contactGoalCount = UserDefaults.standard.contactGoalCount
+        contactGoalCount += 1
+        UserDefaults.standard.contactGoalCount = contactGoalCount
+        UserDefaults.standard.isFeedbackPresented = true
+    }
 }

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -64,9 +64,7 @@ final class UserDefaultsStateManager {
         let isUserTodayContacted = UserDefaults.standard.isUserTodayContacted
         if !isUserTodayContacted {
             UserDefaults.standard.finalContactDiffDay = 0
-            var contactGoalCount = UserDefaults.standard.contactGoalCount
-            contactGoalCount += 1
-            UserDefaults.standard.contactGoalCount = contactGoalCount
+            UserDefaults.standard.contactGoalCount += 1
             userNotificationManager.updateRequestPendingContent()
             UserDefaults.standard.isUserTodayContacted = true
         }

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -62,9 +62,6 @@ final class UserDefaultsStateManager {
             UserDefaults.standard.contactGoalCount = 0
         }
     }
-    static func userCreatedFamily() {
-        UserDefaults.standard.finalContactDiffDay = 0
-    }
     func userContacted() {
         let isUserTodayContacted = UserDefaults.standard.isUserTodayContacted
         if !isUserTodayContacted {

--- a/AMaDda/Model/UserDefaultsStateManager.swift
+++ b/AMaDda/Model/UserDefaultsStateManager.swift
@@ -24,7 +24,9 @@ final class UserDefaultsStateManager {
         }
         updateFinalContactDiffDay(offsetDay)
         updateTodayQuestion()
+        updateContactGoalCount(offsetDay)
         UserDefaults.standard.finalEnteredDate = today
+        UserDefaults.standard.isFeedbackPresented = false
     }
     static private func updateFinalContactDiffDay(_ offsetDay: Int) {
         guard var finalContactDiffDay = UserDefaults.standard.finalContactDiffDay else { return }
@@ -40,5 +42,21 @@ final class UserDefaultsStateManager {
         }
         todayQuestionDelegate?.changeTodayQuestion(questionIndex)
         UserDefaults.standard.questionIndex = questionIndex
+    }
+    static private func updateContactGoalCount(_ offsetDay: Int) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "EEEEE"
+        dateFormatter.timeZone = TimeZone(abbreviation: "KST")
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        var checkDate = Date().convertedKoreaDate
+        var daysFromMonday = 0
+        while (dateFormatter.string(from: checkDate) != "월") {
+            guard let pastDate = Calendar.current.date(byAdding: .day, value: -1, to: checkDate) else { return }
+            checkDate = pastDate
+            daysFromMonday += 1
+        }
+        if daysFromMonday < offsetDay {
+            UserDefaults.standard.contactGoalCount = 0
+        }
     }
 }

--- a/AMaDda/Model/UserNotificationManager.swift
+++ b/AMaDda/Model/UserNotificationManager.swift
@@ -18,12 +18,11 @@ final class UserNotificationManager {
         return dateFormatter
     }
     func addRequest() {
-        // TODO: notificationCount 앱 알림 횟수 설정할 떄 pending 삭제 후 UserDefaluts에 등록
+        // TODO: userNotificationCycle 앱 알림 횟수 설정할 떄 pending 삭제 후 UserDefaluts에 등록
         guard let userNotificationCycle = UserDefaults.standard.userNotificationCycle else {
             print("userNotificationCycle 값 없음")
             return
         }
-        // TODO: 앱이 로드될 떄 finalContactCount 갱신 (finalContactDate와 오늘 날짜 차이를 계산하여 갱신 -> 연락하기 버튼을 누르면 0으로 갱신)
         guard var finalContactDiffDay = UserDefaults.standard.finalContactDiffDay else {
             print("finalContactDiffDay 값 없음")
             return

--- a/AMaDda/Screens/Adding/AddingViewController.swift
+++ b/AMaDda/Screens/Adding/AddingViewController.swift
@@ -92,7 +92,6 @@ class AddingViewController: UIViewController {
         guard let text = nickNameTextField.text else { return }
         let familyMember = FamilyMemberData(name: text, characterImageName: characterImageName)
         familyMember.addFamilyMember()
-        UserDefaultsStateManager.userCreatedFamily()
         navigationController?.popViewController(animated: true)
     }
     

--- a/AMaDda/Screens/Adding/AddingViewController.swift
+++ b/AMaDda/Screens/Adding/AddingViewController.swift
@@ -92,6 +92,7 @@ class AddingViewController: UIViewController {
         guard let text = nickNameTextField.text else { return }
         let familyMember = FamilyMemberData(name: text, characterImageName: characterImageName)
         familyMember.addFamilyMember()
+        UserDefaultsStateManager.userCreatedFamily()
         navigationController?.popViewController(animated: true)
     }
     

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -13,7 +13,7 @@ enum CycleViewMode: Equatable {
 
 final class OnboardingTwoViewController: UIViewController {
     
-    var notificationCount: Int = 3
+    var userNotificationCycle: Int = 3
     var cycleViewMode = CycleViewMode.onboarding
     
     // MARK: Properties
@@ -33,7 +33,7 @@ final class OnboardingTwoViewController: UIViewController {
     }()
     private lazy var showNotificationLabel: UILabel = {
         let label = UILabel()
-        label.text = "\(notificationCount)일"
+        label.text = "\(userNotificationCycle)일"
         label.font = .systemFont(ofSize: 40)
         return label
     }()
@@ -55,8 +55,8 @@ final class OnboardingTwoViewController: UIViewController {
     
     // MARK: stepper function
     @objc private func stepperValueChanged(_ stepper: UIStepper) {
-        notificationCount = Int(stepper.value)
-        showNotificationLabel.text = "\(notificationCount)일"
+        userNotificationCycle = Int(stepper.value)
+        showNotificationLabel.text = "\(userNotificationCycle)일"
     }
     
     @objc private func didTapStartButton() {
@@ -69,7 +69,7 @@ final class OnboardingTwoViewController: UIViewController {
         case .setting:
             navigationController?.popViewController(animated: true)
         }
-        UserDefaults.standard.notificationCount = notificationCount
+        UserDefaults.standard.userNotificationCycle = userNotificationCycle
     }
     
     // MARK: Life Cycle functions
@@ -83,9 +83,9 @@ final class OnboardingTwoViewController: UIViewController {
     // MARK: - Functions
     private func checkCycleViewMode() {
         if case CycleViewMode.setting = cycleViewMode {
-            guard let notificationCycle = UserDefaults.standard.notificationCount else { return }
-            onboardingStepper.value = Double(notificationCycle)
-            showNotificationLabel.text = "\(notificationCycle)일"
+            guard let userNotificationCycle = UserDefaults.standard.userNotificationCycle else { return }
+            onboardingStepper.value = Double(userNotificationCycle)
+            showNotificationLabel.text = "\(userNotificationCycle)일"
         }
     }
     

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -69,7 +69,7 @@ final class OnboardingTwoViewController: UIViewController {
         case .setting:
             navigationController?.popViewController(animated: true)
         }
-        UserDefaults.standard.userNotificationCycle = userNotificationCycle
+        UserDefaultsStateManager().userChangeNotificationCycle(changedNotificationCycle: userNotificationCycle)
     }
     
     // MARK: Life Cycle functions

--- a/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
+++ b/AMaDda/Screens/Onboarding/OnboardingTwoViewController.swift
@@ -69,7 +69,7 @@ final class OnboardingTwoViewController: UIViewController {
         case .setting:
             navigationController?.popViewController(animated: true)
         }
-        UserDefaultsStateManager().userChangeNotificationCycle(changedNotificationCycle: userNotificationCycle)
+        UserDefaultsStateManager().userChangeNotificationCycle(userNotificationCycle)
     }
     
     // MARK: Life Cycle functions


### PR DESCRIPTION
# 이슈 번호
🔒 Close #95 
🔒 Close #96 

## 구현 / 변경 사항 이유

<!-- 구현 / 변경한 내용과 그 이유를 적어주세요. -->
### 알림 목표 기능을 구현하였습니다.
> UserDefaults
- `userContactGoal` - 유저가 설정하는 연락 목표 횟수입니다. 혹시 값이 없을경우를 대비해 2를 기본값으로 주었습니다.
- `contactGoalCount` - 매주 (월~일) 까지 유저가 달성한 연락 횟수입니다. 기본값은 0입니다.
- `isUserTodayContacted` - 유저가 오늘 연락 했는지 안했는지 판별하는 값입니다.

> Method
- `updateContactGoalCount` - 마지막 접속날짜와 현재 접속날짜의 차이 (offsetDay)와 오늘과 이번주 월요일의 차이 (daysFromMonday)를 비교하여 한주가 지났는지 판별하는 메소드입니다. 한주가 지났다면 contactGoalCount를 0으로 초기화 합니다.

### 만들어뒀던 알림 기능을 추가하였습니다.
- 묵혀뒀던 알림 기능을 SceneDelegate에 추가하였습니다.
- **notificationCount를 삭제하였습니다. 온보딩의 notificationCount -> userNotificationCycle로 네이밍을 모두 변경&통일 하였습니다.**

### 알림 목표와 알림 기능의 추가로 유저의 액션에 기반한 메소드를 UserDefaultsStateManager에 추가하였습니다.
- `userContacted` - 유저가 연락을 했을 떄 UserDefaults의 값들을 갱신하고 등록된 알림의 내용을 변경함 **(conflict 날까봐 아직 연결은 안했어요)**
- `userChangeNotificationCycle` - 유저가 userNotificationCycle을 설정했을 때 값을 갱신하고 등록되어 있는 알림을 제거함


## 리뷰 포인트

- @seongmin221 연락 버튼을 누르면 UserStateManager의 userContacted() 호출해야합니다!
- @dangsal 연락 피드백 뷰에서 사용될 UserDefaults 값들이 있습니다! 꼭 확인해주세요.
- @YebinKim UserDefaultsStateManager를 중점적으로 봐주시면 감사하겠습니다.

## 추후 진행할 사항

- [ ] 밀렸던 리팩토링 가동
- [ ] 그림그리기?

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

