### PR TITLE
[BUG] 버튼 무시되는 문제 해결

### DIFF
--- a/AMaDda/Global/Extension/UIViewController+Extension.swift
+++ b/AMaDda/Global/Extension/UIViewController+Extension.swift
@@ -27,14 +27,20 @@ extension UIViewController {
 }
 #endif
 
-extension UIViewController {
+extension UIViewController: UIGestureRecognizerDelegate {
     func hidekeyboardWhenTappedAround() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false
+        tap.delegate = self
         view.addGestureRecognizer(tap)
     }
     
     @objc func dismissKeyboard() {
         view.endEditing(true)
+    }
+
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        guard touch.view is UIButton else { return true }
+        return false
     }
 }


### PR DESCRIPTION
# 이슈 번호
🔒 Close #100

## 구현 / 변경 사항 이유
기존에 아래와 같이 버튼을 눌러도 버튼의 액션이 작동하지 않는 문제가 있었습니다.
![Simulator Screen Recording - iPhone 13 - 2022-07-28 at 23 11 56](https://user-images.githubusercontent.com/26588989/181534062-b12727b1-79bc-4646-b42e-e3b7bc0f5e1b.gif)

이와 관련하여 gesture recognizer의 delegate를 이용하여 아래와 같이 해결하였습니다.
해당 터치의 view가 UIButton이라면 해당 함수가 false를 반환하도록 하여 UIGestureRecognizer가 touch object를 처리하지 못하도록 해줬습니다.
![Simulator Screen Recording - iPhone 13 - 2022-07-28 at 23 12 17](https://user-images.githubusercontent.com/26588989/181534237-64e3bc7c-9564-4502-8016-fbb979a45555.gif)
## References
https://developer.apple.com/documentation/uikit/uigesturerecognizerdelegate/1624214-gesturerecognizer

## 리뷰포인트
extension UIViewControl에 delegate를 채택하는 부분의 함수를 보면 public func gestureRecognizer()가 있습니다
해당 함수를 public으로 하지 않으면 아래와 같은 에러가 발생합니다
 `must be declared public because it matches a requirement in public protocol 'UIGestureRecognizerDelegate'`
이유가 뭘까요?

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

