### PR TITLE
[BUG] empty cell out of range error

### DIFF
--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -168,12 +168,14 @@ extension MainViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        
-        let familyMember = familyMembers[indexPath.row]
-        let EditVC = EdittingViewController()
-        EditVC.familyMember = familyMember
-        navigationController?.pushViewController(EditVC, animated: true)
+        if 0 != familyMemberCount {
+            tableView.deselectRow(at: indexPath, animated: true)
+            
+            let familyMember = familyMembers[indexPath.row]
+            let EditVC = EdittingViewController()
+            EditVC.familyMember = familyMember
+            navigationController?.pushViewController(EditVC, animated: true)
+        }
     }
 }
 

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -168,7 +168,7 @@ extension MainViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if 0 != familyMemberCount {
+        if familyMemberCount != 0 {
             tableView.deselectRow(at: indexPath, animated: true)
             let familyMember = familyMembers[indexPath.row]
             let EditVC = EdittingViewController()

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -170,7 +170,6 @@ extension MainViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if 0 != familyMemberCount {
             tableView.deselectRow(at: indexPath, animated: true)
-            
             let familyMember = familyMembers[indexPath.row]
             let EditVC = EdittingViewController()
             EditVC.familyMember = familyMember


### PR DESCRIPTION
# 이슈 번호
🔒 Close #101 

## 구현 / 변경 사항 이유
empty table cell을 select 했을 때 UITableViewDelegate의 didSelect 함수가 실행되어서 out of range 문제가 발생
이 문제 해결을 위해서 가족 멤버가 0일때는 문제가 없도록 해결
<img width="300" src="https://user-images.githubusercontent.com/26588989/181660718-8f1b1da3-fbb0-4188-b083-df4a8fe1ee4a.png" />

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

