### PR TITLE
[CHORE] fixed profile image size

### DIFF
--- a/AMaDda/Screens/Main/Views/FamilyTableCell.swift
+++ b/AMaDda/Screens/Main/Views/FamilyTableCell.swift
@@ -78,7 +78,7 @@ class FamilyTableCell: UITableViewCell {
             familyCharacterImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Size.sideSpacing),
             familyCharacterImageView.topAnchor.constraint(equalTo: topAnchor, constant: Size.topBottomSpacing),
             familyCharacterImageView.heightAnchor.constraint(equalToConstant: 60),
-            familyCharacterImageView.widthAnchor.constraint(equalToConstant: 50),
+            familyCharacterImageView.widthAnchor.constraint(equalToConstant: 60),
         ])
         
         familyNameLabel.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# 이슈 번호
🔒 Close #106 

## 구현 / 변경 사항 이유

<!-- 구현 / 변경한 내용과 그 이유를 적어주세요. -->
- TableView의 Cell의 Profile image size 변경 -> width/height = 50/60 -> 60/60

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

<img width="250" src="https://user-images.githubusercontent.com/72431640/181662192-87849c93-8eff-4e85-b8a8-dd69c1910bc2.png">

## 리뷰 포인트

- 숫자 하나만 변경했습니다^^

## 추후 진행할 사항

- [ ] editing view ui 변경

## References

## Checklist

- [ ] 코딩 컨벤션을 잘 지켰나요?
- [ ] 셀프 코드 리뷰를 한번 했나요?

