### PR TITLE
[FEAT] 추가하기/수정하기 뷰 제목 수정

### DIFF
--- a/AMaDda/Screens/Adding/AddingViewController.swift
+++ b/AMaDda/Screens/Adding/AddingViewController.swift
@@ -16,12 +16,6 @@ class AddingViewController: UIViewController {
     
     // MARK: - property
     
-    private let addingTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "추가하기"
-        label.font = UIFont.systemFont(ofSize: 34, weight: .bold)
-        return label
-    }()
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.btnProfile
@@ -158,8 +152,7 @@ class AddingViewController: UIViewController {
     }
     
     private func configureAddSubView() {
-        view.addSubviews(addingTitleLabel,
-                         profileImageView,
+        view.addSubviews(profileImageView,
                          plusIcon,
                          createNicknameLabel,
                          nickNameTextField,
@@ -169,16 +162,11 @@ class AddingViewController: UIViewController {
     }
     
     private func configureConstraints() {
-        addingTitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            addingTitleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            addingTitleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor,constant: Size.leadingTrailingPadding),
-        ])
         
         profileImageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            profileImageView.topAnchor.constraint(equalTo: addingTitleLabel.bottomAnchor, constant: 37),
+            profileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0),
             profileImageView.widthAnchor.constraint(equalToConstant: 100),
             profileImageView.heightAnchor.constraint(equalTo: profileImageView.widthAnchor, multiplier: 1.5),
         ])

--- a/AMaDda/Screens/Adding/AddingViewController.swift
+++ b/AMaDda/Screens/Adding/AddingViewController.swift
@@ -67,6 +67,7 @@ class AddingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.title = "추가하기"
         configureUI()
         configureAddSubView()
         configureConstraints()

--- a/AMaDda/Screens/Editting/EdittingViewController.swift
+++ b/AMaDda/Screens/Editting/EdittingViewController.swift
@@ -69,6 +69,7 @@ class EdittingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.title = "수정하기"
         configureUI()
         configureAddSubView()
         configureConstraints()

--- a/AMaDda/Screens/Editting/EdittingViewController.swift
+++ b/AMaDda/Screens/Editting/EdittingViewController.swift
@@ -18,12 +18,6 @@ class EdittingViewController: UIViewController {
     
     // MARK: - property
     
-    private let addingTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "수정하기"
-        label.font = UIFont.systemFont(ofSize: 34, weight: .bold)
-        return label
-    }()
     lazy var profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "\(familyMember?.characterImageName ?? "profile.circle")")
@@ -170,8 +164,7 @@ class EdittingViewController: UIViewController {
     }
     
     private func configureAddSubView() {
-        view.addSubviews(addingTitleLabel,
-                         profileImageView,
+        view.addSubviews(profileImageView,
                          plusIcon,
                          createNicknameLabel,
                          nickNameTextField,
@@ -181,16 +174,11 @@ class EdittingViewController: UIViewController {
     }
     
     private func configureConstraints() {
-        addingTitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            addingTitleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            addingTitleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor,constant: Size.leadingTrailingPadding),
-        ])
         
         profileImageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            profileImageView.topAnchor.constraint(equalTo: addingTitleLabel.bottomAnchor),
+            profileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0),
             profileImageView.widthAnchor.constraint(equalToConstant: 100),
             profileImageView.heightAnchor.constraint(equalTo: profileImageView.widthAnchor, multiplier: 1.5),
         ])


### PR DESCRIPTION
# 이슈 번호
🔒 Close #114

## 구현 / 변경 사항 이유
large title을 넣는 대신에 navigation bar에 넣어도 충분히 유저가 해당 페이지가 무엇을 하는 것인지 알 수 있을 것이라고 생각했습니다 (실제 iPhone의 전화번호 추가하는 뷰에서도 navigation bar에 제목이 있음을 발견했습니다).
또한, large title로 인해서 keyboard가 올라왔을 때, textfield가 가려지는 현상이 나타나는데,
일단은 textfield를 보이도록 뷰를 스크롤로 만들기보다는 당장은 large title을 수정하는 방향으로 선택했습니다.

<img width="250" src="https://user-images.githubusercontent.com/50728605/181730882-07930698-f57b-4240-8be8-a13579046aeb.gif">

## 리뷰 포인트
- `configureconstraints()` 에서 `profileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0)` 로 해서 constant를 0으로 줬을 때 가장 깔끔한 것 같아서 이렇게 했는데, 의견을 주시면 감사하겠습니다!

## 추후 진행할 사항
N/A

## References
- [set title](https://stackoverflow.com/questions/25167458/changing-navigation-title-programmatically)

## Checklist
- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

