### PR TITLE
[CHORE] changeTodayQuestion를 Dispatch main queue 처리

### DIFF
--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -243,7 +243,9 @@ extension MainViewController: UITableViewDataSource {
 extension MainViewController: TodayQuestionDelegate {
     func changeTodayQuestion(_ index: Int) {
         guard let todayQuestion = todayQuestion[safe: index] else { return }
-        todayQuestionView.todayCardQuestionLabel.text = todayQuestion.question
+        DispatchQueue.main.async {
+            self.todayQuestionView.todayCardQuestionLabel.text = todayQuestion.question
+        }
     }
 }
 


### PR DESCRIPTION
# 이슈 번호
🔒 Close #86 

## 구현 / 변경 사항 이유

<!-- 구현 / 변경한 내용과 그 이유를 적어주세요. -->
- changeTodayQuestion 메소드가 현재 코드로도 메인 스레드에서 실행되는건 맞지만, 혹여 나중에 다른 스레드에서 이 메소드를 호출하여 문제가 생길 수 있기 떄문에 Dispatch main queue로 꼭 메인 스레드에서 처리가 되도록 하였습니다.

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

## 리뷰 포인트

- 비비에게 설득당했습니다 👻🦜👍

## 추후 진행할 사항

- [ ] #74 

## References

- #136

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

