### PR TITLE
[CHORE] change setting icon&positon

### DIFF
--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -41,12 +41,9 @@ final class MainViewController: UIViewController {
         button.addTarget(self, action: #selector(tapAddButton), for: .touchUpInside)
         return button
     }()
-    private let settingButton: UIButton = {
-        let button = UIButton()
-        let configuaration = UIImage.SymbolConfiguration(pointSize: 24)
-        let image = UIImage.load(systemName: "ellipsis.circle", configuration: configuaration)
-        button.setImage(image, for: .normal)
-        button.showsMenuAsPrimaryAction = true
+    private let settingButton: UIBarButtonItem = {
+        let image = UIImage.load(systemName: "gearshape")
+        let button = UIBarButtonItem(image: image, style: .plain, target: nil, action: nil)
         return button
     }()
     private let feedBackView: FeedBackPopUpView = {
@@ -167,13 +164,13 @@ extension MainViewController {
         familyTableView.backgroundColor = .systemBackground
         setButtonMenu()
         self.navigationItem.setHidesBackButton(true, animated:true)
+        self.navigationItem.rightBarButtonItem = settingButton
     }
     private func configureAddSubViews() {
         view.addSubviews(todayQuestionView,
                          familyTableLabel,
                          familyTableView,
                         addMemberButton,
-                        settingButton,
                          blurEffectView)
         todayQuestionView.configureAddSubViewsTodayQuestionView()
     }
@@ -209,14 +206,6 @@ extension MainViewController {
             addMemberButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
             addMemberButton.heightAnchor.constraint(equalToConstant: touchAreaSize),
             addMemberButton.widthAnchor.constraint(equalToConstant: touchAreaSize),
-        ])
-        
-        settingButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            settingButton.centerYAnchor.constraint(equalTo: todayQuestionView.todayTitleLabel.centerYAnchor),
-            settingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
-            settingButton.heightAnchor.constraint(equalToConstant: touchAreaSize),
-            settingButton.widthAnchor.constraint(equalToConstant: touchAreaSize),
         ])
         
         blurEffectView.translatesAutoresizingMaskIntoConstraints = false

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -182,7 +182,7 @@ extension MainViewController {
             todayQuestionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             todayQuestionView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: Size.leadingTrailingPadding),
             todayQuestionView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -Size.leadingTrailingPadding),
-            todayQuestionView.heightAnchor.constraint(equalToConstant: 170),
+            todayQuestionView.heightAnchor.constraint(equalToConstant: 140),
         ])
         todayQuestionView.configureConstraintsTodayQuestionView()
         

--- a/AMaDda/Screens/Main/MainViewController.swift
+++ b/AMaDda/Screens/Main/MainViewController.swift
@@ -203,7 +203,7 @@ extension MainViewController {
         addMemberButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             addMemberButton.centerYAnchor.constraint(equalTo: familyTableLabel.centerYAnchor),
-            addMemberButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Size.leadingTrailingPadding),
+            addMemberButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -5),
             addMemberButton.heightAnchor.constraint(equalToConstant: touchAreaSize),
             addMemberButton.widthAnchor.constraint(equalToConstant: touchAreaSize),
         ])

--- a/AMaDda/Screens/Main/Views/TodayQuestionView.swift
+++ b/AMaDda/Screens/Main/Views/TodayQuestionView.swift
@@ -64,7 +64,7 @@ extension TodayQuestionView {
         
         todayCardQuestionLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            todayCardQuestionLabel.centerYAnchor.constraint(equalTo: todayCardView.centerYAnchor),
+            todayCardQuestionLabel.centerYAnchor.constraint(equalTo: todayCardView.centerYAnchor, constant: 10),
             todayCardQuestionLabel.centerXAnchor.constraint(equalTo: todayCardView.centerXAnchor),
             todayCardQuestionLabel.widthAnchor.constraint(lessThanOrEqualTo: todayCardView.widthAnchor, constant: -50)
         ])


### PR DESCRIPTION
# 이슈 번호
#150 (진행중)

## 구현 / 변경 사항 이유

<!-- 구현 / 변경한 내용과 그 이유를 적어주세요. -->

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

<img width="250" alt="image" src="https://user-images.githubusercontent.com/56781342/183039249-9ef0a752-6fc5-4245-903c-40a3678eda83.png"> <img width="250" alt="image" src="https://user-images.githubusercontent.com/56781342/183039598-329c24ad-3abe-459b-94d7-a3d3b29c59f7.png">

- 메인 뷰의 설정 ... 아이콘을 gear 이미지로 변경, 위치를 네비게이션 barItem으로 조정

<img width="250" alt="image" src="https://user-images.githubusercontent.com/56781342/183041375-b7860fa3-0709-4458-ad7d-c596c28692de.png">

- 오늘의 질문과 우리 가족의 간격 좁힘

## 리뷰 포인트

- gear 아이콘을 수정한 두개의 이미지 중 왼쪽은 그냥 navigationBarItem에 달아놓은 모습이고, 오른쪽은 imageInset을 줘서 아래 + 버튼이랑 위치를 맞춘 모습입니다. 개인적으로는 왼쪽이 괜찮은 것 같은데 어떤가요?

## 추후 진행할 사항

- [ ] 오늘의 질문 UI 수정
- [ ] BUG 날짜 바뀌고 앱을 껐다가 켜야 "오늘 연락했어요" 문구가 바뀜 오류 해결

## Checklist

- [x] 코딩 컨벤션을 잘 지켰나요?
- [x] 셀프 코드 리뷰를 한번 했나요?

