### PR TITLE
[BUG] 알림목표 설정 다크모드 해결

### DIFF
--- a/AMaDda/Screens/SettingGoalViewController/SettingGoalViewController.swift
+++ b/AMaDda/Screens/SettingGoalViewController/SettingGoalViewController.swift
@@ -49,6 +49,7 @@ class SettingGoalViewController: UIViewController {
         let button = CommonButton()
         let buttonTitle = "저장하기"
         button.setTitle(buttonTitle, for: .normal)
+        button.setTitleColor(UIColor.systemBackground, for: .normal)
         button.addTarget(self, action: #selector(didTapStartButton), for: .touchUpInside)
         return button
     }()


### PR DESCRIPTION
# 이슈 번호
🔒 Close #175 

## 구현 / 변경 사항 이유
알림 목표 설정 창에서 버튼의 글자가 다크모드에서 보이지 않는 버그 해결
<img width="250" src="https://user-images.githubusercontent.com/50728605/184538997-1b4efe8d-e7d1-4dc2-b853-52543d3abf35.png">

## 리뷰 포인트
N/A

## 추후 진행할 사항
N/A

## References
N/A

## Checklist
- [ ] 코딩 컨벤션을 잘 지켰나요?
- [ ] 셀프 코드 리뷰를 한번 했나요?

